### PR TITLE
Update Extends to not distribute over union types

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,13 @@ expectTypeOf(1).not.toBeUndefined()
 expectTypeOf(1).not.toBeNullable()
 ```
 
+Detect assignability of unioned types:
+
+```typescript
+expectTypeOf<number>().toMatchTypeOf<string | number>()
+expectTypeOf<string | number>().not.toMatchTypeOf<number>()
+```
+
 Use `.extract` and `.exclude` to narrow down complex union types:
 
 ```typescript

--- a/src/index.ts
+++ b/src/index.ts
@@ -80,7 +80,7 @@ type ReadonlyEquivalent<X, Y> = Extends<
   (<T>() => T extends Y ? true : false)
 >
 
-export type Extends<L, R> = IsNever<L> extends true ? IsNever<R> : L extends R ? true : false
+export type Extends<L, R> = IsNever<L> extends true ? IsNever<R> : [L] extends [R] ? true : false
 export type StrictExtends<L, R> = Extends<DeepBrand<L>, DeepBrand<R>>
 
 export type Equal<Left, Right> = And<[StrictExtends<Left, Right>, StrictExtends<Right, Left>]>

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -101,6 +101,11 @@ test('More `.not` examples', () => {
   expectTypeOf(1).not.toBeNullable()
 })
 
+test('Detect assignability of unioned types', () => {
+  expectTypeOf<number>().toMatchTypeOf<string | number>()
+  expectTypeOf<string | number>().not.toMatchTypeOf<number>()
+})
+
 test('Use `.extract` and `.exclude` to narrow down complex union types', () => {
   type ResponsiveProp<T> = T | T[] | {xs?: T; sm?: T; md?: T}
   const getResponsiveProp = <T>(_props: T): ResponsiveProp<T> => ({})


### PR DESCRIPTION
Was attempting to use `expectTypeOf` with unioned types and I was surprised that `expectTypeOf` was always mismatching.

See [this repro](https://www.typescriptlang.org/play?#code/C4TwDgpgBAogHsCA7AJgZwDwBkA0UBKAfFALxRZQQLLoFQD8UwATgK7QBcUAZgIYA2aCAG4AUKNCQoASVQBLZhADGwfiFKxqqTGhZykAcwA+SVgFsARhGZ5Tl60YtyD+4ITEB6D1B9QAevQS4NAAIgrKqupkusz6xnZWzJRatAkOTi5IwAxMbJw8AkKe3r4B4kFSAGJycBAo8Ija2HhEGgDaWAC6yY20bfjdjCzsUFx8giLiktDVtSiyKOEqahqzdQ00OnqGJuaJtnvpzq7uol6+-oFAA) showcasing the problems of union types that get stuck in `Extends`.

Note: This only impacts the LHS of the extends.