### PR TITLE
port throw types PR from mmkal/ts#152

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,6 @@
     "jest": "28.1.3",
     "np": "7.6.2",
     "ts-jest": "28.0.8",
-    "typescript": "4.8.2"
+    "typescript": "npm:@typescript-deploys/pr-build@4.2.0-pr-40468-44"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,16 +7,16 @@ specifiers:
   jest: 28.1.3
   np: 7.6.2
   ts-jest: 28.0.8
-  typescript: 4.8.2
+  typescript: npm:@typescript-deploys/pr-build@4.2.0-pr-40468-44
 
 devDependencies:
   '@types/jest': 29.0.0
   eslint: 8.23.0
-  eslint-plugin-mmkal: 0.0.1-2_njvpd7oexm4jrpqkdx4xx3mxbm
+  eslint-plugin-mmkal: 0.0.1-2_yhp3vwibthsaghedlibvwbska4
   jest: 28.1.3
   np: 7.6.2
-  ts-jest: 28.0.8_556mfp7b5dutuj2jcrj5i7zc5q
-  typescript: 4.8.2
+  ts-jest: 28.0.8_oxbhxmmeuefahdnbgyz5vo3yqq
+  typescript: /@typescript-deploys/pr-build/4.2.0-pr-40468-44
 
 packages:
 
@@ -752,25 +752,25 @@ packages:
       fastq: 1.13.0
     dev: true
 
-  /@rushstack/eslint-config/3.1.1_yqf6kl63nyoq5megxukfnom5rm:
+  /@rushstack/eslint-config/3.1.1_eupmungbvhwcvwehlcd3ix3awy:
     resolution: {integrity: sha512-hlpXiEPQDHXWtI+iGm9sJjnfm5qOEJsQN7pN004b1ZYq+g3MsE+QvTamalMAcdvXrsnH5Lo0XPfHuEJCa7nwPA==}
     peerDependencies:
       eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
       typescript: '>=4.7.0'
     dependencies:
       '@rushstack/eslint-patch': 1.2.0
-      '@rushstack/eslint-plugin': 0.11.0_yqf6kl63nyoq5megxukfnom5rm
-      '@rushstack/eslint-plugin-packlets': 0.6.1_yqf6kl63nyoq5megxukfnom5rm
-      '@rushstack/eslint-plugin-security': 0.5.0_yqf6kl63nyoq5megxukfnom5rm
-      '@typescript-eslint/eslint-plugin': 5.38.1_wngjumgc3dlvz7rlbb66uyvpxi
-      '@typescript-eslint/experimental-utils': 5.38.1_yqf6kl63nyoq5megxukfnom5rm
-      '@typescript-eslint/parser': 5.38.1_yqf6kl63nyoq5megxukfnom5rm
-      '@typescript-eslint/typescript-estree': 5.38.1_typescript@4.8.2
+      '@rushstack/eslint-plugin': 0.11.0_eupmungbvhwcvwehlcd3ix3awy
+      '@rushstack/eslint-plugin-packlets': 0.6.1_eupmungbvhwcvwehlcd3ix3awy
+      '@rushstack/eslint-plugin-security': 0.5.0_eupmungbvhwcvwehlcd3ix3awy
+      '@typescript-eslint/eslint-plugin': 5.38.1_q3npv6ky3yxckhepxfgxv5pila
+      '@typescript-eslint/experimental-utils': 5.38.1_eupmungbvhwcvwehlcd3ix3awy
+      '@typescript-eslint/parser': 5.38.1_eupmungbvhwcvwehlcd3ix3awy
+      '@typescript-eslint/typescript-estree': 5.38.1_w3becoyqwjurswhufoizdhlxii
       eslint: 8.23.0
       eslint-plugin-promise: 6.0.1_eslint@8.23.0
       eslint-plugin-react: 7.27.1_eslint@8.23.0
       eslint-plugin-tsdoc: 0.2.17
-      typescript: 4.8.2
+      typescript: /@typescript-deploys/pr-build/4.2.0-pr-40468-44
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -779,78 +779,78 @@ packages:
     resolution: {integrity: sha512-sXo/qW2/pAcmT43VoRKOJbDOfV3cYpq3szSVfIThQXNt+E4DfKj361vaAt3c88U5tPUxzEswam7GW48PJqtKAg==}
     dev: true
 
-  /@rushstack/eslint-plugin-packlets/0.5.0_yqf6kl63nyoq5megxukfnom5rm:
+  /@rushstack/eslint-plugin-packlets/0.5.0_eupmungbvhwcvwehlcd3ix3awy:
     resolution: {integrity: sha512-I160nHeAGzA0q4g3cR7kiHNgiU1HqrYto52+lEmxLAdbBllqc6IOyiWQfCDb5ug0f+Y8bTwMQHiUrI7XclZB/Q==}
     peerDependencies:
       eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
     dependencies:
       '@rushstack/tree-pattern': 0.2.4
-      '@typescript-eslint/experimental-utils': 5.30.7_yqf6kl63nyoq5megxukfnom5rm
+      '@typescript-eslint/experimental-utils': 5.30.7_eupmungbvhwcvwehlcd3ix3awy
       eslint: 8.23.0
     transitivePeerDependencies:
       - supports-color
       - typescript
     dev: true
 
-  /@rushstack/eslint-plugin-packlets/0.6.1_yqf6kl63nyoq5megxukfnom5rm:
+  /@rushstack/eslint-plugin-packlets/0.6.1_eupmungbvhwcvwehlcd3ix3awy:
     resolution: {integrity: sha512-N0GqjUbpQ4X348BTLr+gUGVojFVrXwbT3YQv/5sP5adYzq8bOKarmSHKXpvl4rC4CKPDfdSKxTMPfu3P3CJVSA==}
     peerDependencies:
       eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
     dependencies:
       '@rushstack/tree-pattern': 0.2.4
-      '@typescript-eslint/experimental-utils': 5.38.1_yqf6kl63nyoq5megxukfnom5rm
+      '@typescript-eslint/experimental-utils': 5.38.1_eupmungbvhwcvwehlcd3ix3awy
       eslint: 8.23.0
     transitivePeerDependencies:
       - supports-color
       - typescript
     dev: true
 
-  /@rushstack/eslint-plugin-security/0.4.0_yqf6kl63nyoq5megxukfnom5rm:
+  /@rushstack/eslint-plugin-security/0.4.0_eupmungbvhwcvwehlcd3ix3awy:
     resolution: {integrity: sha512-jRFtrOnZZcuJ2MRA9RtoeyKiFQ60iKu7SDF1wkc7M9nHL5C1HkFApX6nTlAjY7C5B7UlV+9BP9fDmOJJmB4FSw==}
     peerDependencies:
       eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
     dependencies:
       '@rushstack/tree-pattern': 0.2.4
-      '@typescript-eslint/experimental-utils': 5.30.7_yqf6kl63nyoq5megxukfnom5rm
+      '@typescript-eslint/experimental-utils': 5.30.7_eupmungbvhwcvwehlcd3ix3awy
       eslint: 8.23.0
     transitivePeerDependencies:
       - supports-color
       - typescript
     dev: true
 
-  /@rushstack/eslint-plugin-security/0.5.0_yqf6kl63nyoq5megxukfnom5rm:
+  /@rushstack/eslint-plugin-security/0.5.0_eupmungbvhwcvwehlcd3ix3awy:
     resolution: {integrity: sha512-qDtij3D2DY8VDHKeUdf+M2SpoctrY+eIA+fJFkpuHP7CTJZLBv5186+oCsJ59lZmKoBFREdgpaV3coXamoT8RQ==}
     peerDependencies:
       eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
     dependencies:
       '@rushstack/tree-pattern': 0.2.4
-      '@typescript-eslint/experimental-utils': 5.38.1_yqf6kl63nyoq5megxukfnom5rm
+      '@typescript-eslint/experimental-utils': 5.38.1_eupmungbvhwcvwehlcd3ix3awy
       eslint: 8.23.0
     transitivePeerDependencies:
       - supports-color
       - typescript
     dev: true
 
-  /@rushstack/eslint-plugin/0.10.0_yqf6kl63nyoq5megxukfnom5rm:
+  /@rushstack/eslint-plugin/0.10.0_eupmungbvhwcvwehlcd3ix3awy:
     resolution: {integrity: sha512-39DCBD6s7Y5XQxvcMmitXfupkReGcg0lmtil9mrGHkDoyiUln90sOWtpkSl6LqUrSL3lx7N2wRvJiJlwGIPYFQ==}
     peerDependencies:
       eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
     dependencies:
       '@rushstack/tree-pattern': 0.2.4
-      '@typescript-eslint/experimental-utils': 5.30.7_yqf6kl63nyoq5megxukfnom5rm
+      '@typescript-eslint/experimental-utils': 5.30.7_eupmungbvhwcvwehlcd3ix3awy
       eslint: 8.23.0
     transitivePeerDependencies:
       - supports-color
       - typescript
     dev: true
 
-  /@rushstack/eslint-plugin/0.11.0_yqf6kl63nyoq5megxukfnom5rm:
+  /@rushstack/eslint-plugin/0.11.0_eupmungbvhwcvwehlcd3ix3awy:
     resolution: {integrity: sha512-e8eVBOgb/xkpkgFmPP+oifrqCLh8I5BFI/emB/nf5+WnuS4hsTHkgprCEiJuvkhJRypsWrbchkIda9/1YFadxg==}
     peerDependencies:
       eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
     dependencies:
       '@rushstack/tree-pattern': 0.2.4
-      '@typescript-eslint/experimental-utils': 5.38.1_yqf6kl63nyoq5megxukfnom5rm
+      '@typescript-eslint/experimental-utils': 5.38.1_eupmungbvhwcvwehlcd3ix3awy
       eslint: 8.23.0
     transitivePeerDependencies:
       - supports-color
@@ -1070,7 +1070,13 @@ packages:
       '@types/yargs-parser': 21.0.0
     dev: true
 
-  /@typescript-eslint/eslint-plugin/5.38.1_wngjumgc3dlvz7rlbb66uyvpxi:
+  /@typescript-deploys/pr-build/4.2.0-pr-40468-44:
+    resolution: {integrity: sha512-KJUcd8WRFNgPUAeasAgXhQEyYUKrMYxeyLuSCLUJHii4TFDVUCrhn4iEcE3AwBMqGJWTEXLPo6NyHsysskh7rA==}
+    engines: {node: '>=4.2.0'}
+    hasBin: true
+    dev: true
+
+  /@typescript-eslint/eslint-plugin/5.38.1_q3npv6ky3yxckhepxfgxv5pila:
     resolution: {integrity: sha512-ky7EFzPhqz3XlhS7vPOoMDaQnQMn+9o5ICR9CPr/6bw8HrFkzhMSxuA3gRfiJVvs7geYrSeawGJjZoZQKCOglQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -1081,22 +1087,22 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 5.38.1_yqf6kl63nyoq5megxukfnom5rm
+      '@typescript-eslint/parser': 5.38.1_eupmungbvhwcvwehlcd3ix3awy
       '@typescript-eslint/scope-manager': 5.38.1
-      '@typescript-eslint/type-utils': 5.38.1_yqf6kl63nyoq5megxukfnom5rm
-      '@typescript-eslint/utils': 5.38.1_yqf6kl63nyoq5megxukfnom5rm
+      '@typescript-eslint/type-utils': 5.38.1_eupmungbvhwcvwehlcd3ix3awy
+      '@typescript-eslint/utils': 5.38.1_eupmungbvhwcvwehlcd3ix3awy
       debug: 4.3.4
       eslint: 8.23.0
       ignore: 5.2.0
       regexpp: 3.2.0
       semver: 7.3.8
-      tsutils: 3.21.0_typescript@4.8.2
-      typescript: 4.8.2
+      tsutils: 3.21.0_w3becoyqwjurswhufoizdhlxii
+      typescript: /@typescript-deploys/pr-build/4.2.0-pr-40468-44
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@typescript-eslint/eslint-plugin/5.40.1_ghcq2hxpzlnfizbnoz3v5uflw4:
+  /@typescript-eslint/eslint-plugin/5.40.1_xjfekjuoddwwutqimm6dkbxj6m:
     resolution: {integrity: sha512-FsWboKkWdytGiXT5O1/R9j37YgcjO8MKHSUmWnIEjVaz0krHkplPnYi7mwdb+5+cs0toFNQb0HIrN7zONdIEWg==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -1107,48 +1113,48 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 5.40.1_yqf6kl63nyoq5megxukfnom5rm
+      '@typescript-eslint/parser': 5.40.1_eupmungbvhwcvwehlcd3ix3awy
       '@typescript-eslint/scope-manager': 5.40.1
-      '@typescript-eslint/type-utils': 5.40.1_yqf6kl63nyoq5megxukfnom5rm
-      '@typescript-eslint/utils': 5.40.1_yqf6kl63nyoq5megxukfnom5rm
+      '@typescript-eslint/type-utils': 5.40.1_eupmungbvhwcvwehlcd3ix3awy
+      '@typescript-eslint/utils': 5.40.1_eupmungbvhwcvwehlcd3ix3awy
       debug: 4.3.4
       eslint: 8.23.0
       ignore: 5.2.0
       regexpp: 3.2.0
       semver: 7.3.8
-      tsutils: 3.21.0_typescript@4.8.2
-      typescript: 4.8.2
+      tsutils: 3.21.0_w3becoyqwjurswhufoizdhlxii
+      typescript: /@typescript-deploys/pr-build/4.2.0-pr-40468-44
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@typescript-eslint/experimental-utils/5.30.7_yqf6kl63nyoq5megxukfnom5rm:
+  /@typescript-eslint/experimental-utils/5.30.7_eupmungbvhwcvwehlcd3ix3awy:
     resolution: {integrity: sha512-r218ZVL0zFBYzEq8/9K2ZhRgsmKUhm8xd3sWChgvTbmP98kHGuY83IUl64SS9fx9OSBM9vMLdzBfox4eDdm/ZQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
       eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
     dependencies:
-      '@typescript-eslint/utils': 5.30.7_yqf6kl63nyoq5megxukfnom5rm
+      '@typescript-eslint/utils': 5.30.7_eupmungbvhwcvwehlcd3ix3awy
       eslint: 8.23.0
     transitivePeerDependencies:
       - supports-color
       - typescript
     dev: true
 
-  /@typescript-eslint/experimental-utils/5.38.1_yqf6kl63nyoq5megxukfnom5rm:
+  /@typescript-eslint/experimental-utils/5.38.1_eupmungbvhwcvwehlcd3ix3awy:
     resolution: {integrity: sha512-Zv0EcU0iu64DiVG3pRZU0QYCgANO//U1fS3oEs3eqHD1eIVVcQsFd/T01ckaNbL2H2aCqRojY2xZuMAPcOArEA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
       eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
     dependencies:
-      '@typescript-eslint/utils': 5.38.1_yqf6kl63nyoq5megxukfnom5rm
+      '@typescript-eslint/utils': 5.38.1_eupmungbvhwcvwehlcd3ix3awy
       eslint: 8.23.0
     transitivePeerDependencies:
       - supports-color
       - typescript
     dev: true
 
-  /@typescript-eslint/parser/5.38.1_yqf6kl63nyoq5megxukfnom5rm:
+  /@typescript-eslint/parser/5.38.1_eupmungbvhwcvwehlcd3ix3awy:
     resolution: {integrity: sha512-LDqxZBVFFQnQRz9rUZJhLmox+Ep5kdUmLatLQnCRR6523YV+XhRjfYzStQ4MheFA8kMAfUlclHSbu+RKdRwQKw==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -1160,15 +1166,15 @@ packages:
     dependencies:
       '@typescript-eslint/scope-manager': 5.38.1
       '@typescript-eslint/types': 5.38.1
-      '@typescript-eslint/typescript-estree': 5.38.1_typescript@4.8.2
+      '@typescript-eslint/typescript-estree': 5.38.1_w3becoyqwjurswhufoizdhlxii
       debug: 4.3.4
       eslint: 8.23.0
-      typescript: 4.8.2
+      typescript: /@typescript-deploys/pr-build/4.2.0-pr-40468-44
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@typescript-eslint/parser/5.40.1_yqf6kl63nyoq5megxukfnom5rm:
+  /@typescript-eslint/parser/5.40.1_eupmungbvhwcvwehlcd3ix3awy:
     resolution: {integrity: sha512-IK6x55va5w4YvXd4b3VrXQPldV9vQTxi5ov+g4pMANsXPTXOcfjx08CRR1Dfrcc51syPtXHF5bgLlMHYFrvQtg==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -1180,10 +1186,10 @@ packages:
     dependencies:
       '@typescript-eslint/scope-manager': 5.40.1
       '@typescript-eslint/types': 5.40.1
-      '@typescript-eslint/typescript-estree': 5.40.1_typescript@4.8.2
+      '@typescript-eslint/typescript-estree': 5.40.1_w3becoyqwjurswhufoizdhlxii
       debug: 4.3.4
       eslint: 8.23.0
-      typescript: 4.8.2
+      typescript: /@typescript-deploys/pr-build/4.2.0-pr-40468-44
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -1212,7 +1218,7 @@ packages:
       '@typescript-eslint/visitor-keys': 5.40.1
     dev: true
 
-  /@typescript-eslint/type-utils/5.38.1_yqf6kl63nyoq5megxukfnom5rm:
+  /@typescript-eslint/type-utils/5.38.1_eupmungbvhwcvwehlcd3ix3awy:
     resolution: {integrity: sha512-UU3j43TM66gYtzo15ivK2ZFoDFKKP0k03MItzLdq0zV92CeGCXRfXlfQX5ILdd4/DSpHkSjIgLLLh1NtkOJOAw==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -1222,17 +1228,17 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/typescript-estree': 5.38.1_typescript@4.8.2
-      '@typescript-eslint/utils': 5.38.1_yqf6kl63nyoq5megxukfnom5rm
+      '@typescript-eslint/typescript-estree': 5.38.1_w3becoyqwjurswhufoizdhlxii
+      '@typescript-eslint/utils': 5.38.1_eupmungbvhwcvwehlcd3ix3awy
       debug: 4.3.4
       eslint: 8.23.0
-      tsutils: 3.21.0_typescript@4.8.2
-      typescript: 4.8.2
+      tsutils: 3.21.0_w3becoyqwjurswhufoizdhlxii
+      typescript: /@typescript-deploys/pr-build/4.2.0-pr-40468-44
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@typescript-eslint/type-utils/5.40.1_yqf6kl63nyoq5megxukfnom5rm:
+  /@typescript-eslint/type-utils/5.40.1_eupmungbvhwcvwehlcd3ix3awy:
     resolution: {integrity: sha512-DLAs+AHQOe6n5LRraXiv27IYPhleF0ldEmx6yBqBgBLaNRKTkffhV1RPsjoJBhVup2zHxfaRtan8/YRBgYhU9Q==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -1242,12 +1248,12 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/typescript-estree': 5.40.1_typescript@4.8.2
-      '@typescript-eslint/utils': 5.40.1_yqf6kl63nyoq5megxukfnom5rm
+      '@typescript-eslint/typescript-estree': 5.40.1_w3becoyqwjurswhufoizdhlxii
+      '@typescript-eslint/utils': 5.40.1_eupmungbvhwcvwehlcd3ix3awy
       debug: 4.3.4
       eslint: 8.23.0
-      tsutils: 3.21.0_typescript@4.8.2
-      typescript: 4.8.2
+      tsutils: 3.21.0_w3becoyqwjurswhufoizdhlxii
+      typescript: /@typescript-deploys/pr-build/4.2.0-pr-40468-44
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -1267,7 +1273,7 @@ packages:
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dev: true
 
-  /@typescript-eslint/typescript-estree/5.30.7_typescript@4.8.2:
+  /@typescript-eslint/typescript-estree/5.30.7_w3becoyqwjurswhufoizdhlxii:
     resolution: {integrity: sha512-tNslqXI1ZdmXXrHER83TJ8OTYl4epUzJC0aj2i4DMDT4iU+UqLT3EJeGQvJ17BMbm31x5scSwo3hPM0nqQ1AEA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -1282,13 +1288,13 @@ packages:
       globby: 11.1.0
       is-glob: 4.0.3
       semver: 7.3.8
-      tsutils: 3.21.0_typescript@4.8.2
-      typescript: 4.8.2
+      tsutils: 3.21.0_w3becoyqwjurswhufoizdhlxii
+      typescript: /@typescript-deploys/pr-build/4.2.0-pr-40468-44
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@typescript-eslint/typescript-estree/5.38.1_typescript@4.8.2:
+  /@typescript-eslint/typescript-estree/5.38.1_w3becoyqwjurswhufoizdhlxii:
     resolution: {integrity: sha512-99b5e/Enoe8fKMLdSuwrfH/C0EIbpUWmeEKHmQlGZb8msY33qn1KlkFww0z26o5Omx7EVjzVDCWEfrfCDHfE7g==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -1303,13 +1309,13 @@ packages:
       globby: 11.1.0
       is-glob: 4.0.3
       semver: 7.3.8
-      tsutils: 3.21.0_typescript@4.8.2
-      typescript: 4.8.2
+      tsutils: 3.21.0_w3becoyqwjurswhufoizdhlxii
+      typescript: /@typescript-deploys/pr-build/4.2.0-pr-40468-44
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@typescript-eslint/typescript-estree/5.40.1_typescript@4.8.2:
+  /@typescript-eslint/typescript-estree/5.40.1_w3becoyqwjurswhufoizdhlxii:
     resolution: {integrity: sha512-5QTP/nW5+60jBcEPfXy/EZL01qrl9GZtbgDZtDPlfW5zj/zjNrdI2B5zMUHmOsfvOr2cWqwVdWjobCiHcedmQA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -1324,13 +1330,13 @@ packages:
       globby: 11.1.0
       is-glob: 4.0.3
       semver: 7.3.8
-      tsutils: 3.21.0_typescript@4.8.2
-      typescript: 4.8.2
+      tsutils: 3.21.0_w3becoyqwjurswhufoizdhlxii
+      typescript: /@typescript-deploys/pr-build/4.2.0-pr-40468-44
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@typescript-eslint/utils/5.30.7_yqf6kl63nyoq5megxukfnom5rm:
+  /@typescript-eslint/utils/5.30.7_eupmungbvhwcvwehlcd3ix3awy:
     resolution: {integrity: sha512-Z3pHdbFw+ftZiGUnm1GZhkJgVqsDL5CYW2yj+TB2mfXDFOMqtbzQi2dNJIyPqPbx9mv2kUxS1gU+r2gKlKi1rQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -1339,7 +1345,7 @@ packages:
       '@types/json-schema': 7.0.11
       '@typescript-eslint/scope-manager': 5.30.7
       '@typescript-eslint/types': 5.30.7
-      '@typescript-eslint/typescript-estree': 5.30.7_typescript@4.8.2
+      '@typescript-eslint/typescript-estree': 5.30.7_w3becoyqwjurswhufoizdhlxii
       eslint: 8.23.0
       eslint-scope: 5.1.1
       eslint-utils: 3.0.0_eslint@8.23.0
@@ -1348,7 +1354,7 @@ packages:
       - typescript
     dev: true
 
-  /@typescript-eslint/utils/5.38.1_yqf6kl63nyoq5megxukfnom5rm:
+  /@typescript-eslint/utils/5.38.1_eupmungbvhwcvwehlcd3ix3awy:
     resolution: {integrity: sha512-oIuUiVxPBsndrN81oP8tXnFa/+EcZ03qLqPDfSZ5xIJVm7A9V0rlkQwwBOAGtrdN70ZKDlKv+l1BeT4eSFxwXA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -1357,7 +1363,7 @@ packages:
       '@types/json-schema': 7.0.11
       '@typescript-eslint/scope-manager': 5.38.1
       '@typescript-eslint/types': 5.38.1
-      '@typescript-eslint/typescript-estree': 5.38.1_typescript@4.8.2
+      '@typescript-eslint/typescript-estree': 5.38.1_w3becoyqwjurswhufoizdhlxii
       eslint: 8.23.0
       eslint-scope: 5.1.1
       eslint-utils: 3.0.0_eslint@8.23.0
@@ -1366,7 +1372,7 @@ packages:
       - typescript
     dev: true
 
-  /@typescript-eslint/utils/5.40.1_yqf6kl63nyoq5megxukfnom5rm:
+  /@typescript-eslint/utils/5.40.1_eupmungbvhwcvwehlcd3ix3awy:
     resolution: {integrity: sha512-a2TAVScoX9fjryNrW6BZRnreDUszxqm9eQ9Esv8n5nXApMW0zeANUYlwh/DED04SC/ifuBvXgZpIK5xeJHQ3aw==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -1376,7 +1382,7 @@ packages:
       '@types/semver': 7.3.12
       '@typescript-eslint/scope-manager': 5.40.1
       '@typescript-eslint/types': 5.40.1
-      '@typescript-eslint/typescript-estree': 5.40.1_typescript@4.8.2
+      '@typescript-eslint/typescript-estree': 5.40.1_w3becoyqwjurswhufoizdhlxii
       eslint: 8.23.0
       eslint-scope: 5.1.1
       eslint-utils: 3.0.0_eslint@8.23.0
@@ -2333,7 +2339,7 @@ packages:
       eslint-plugin-react-hooks: 4.6.0_eslint@8.23.0
     dev: true
 
-  /eslint-config-xo-typescript/0.53.0_yqruj2vud6favyjjbpx7uotp7a:
+  /eslint-config-xo-typescript/0.53.0_7x6kqayz46ejm635qzzwiuh6km:
     resolution: {integrity: sha512-IJ1n70egMPTou/41HoGGFbLf/2WCsVW5lSUxOSklrR8T1221fMRPVJxIVZ3evr8R+N5wR6uzg/0uzSymwWA5Bg==}
     engines: {node: '>=12'}
     peerDependencies:
@@ -2342,10 +2348,10 @@ packages:
       eslint: '>=8.0.0'
       typescript: '>=4.4'
     dependencies:
-      '@typescript-eslint/eslint-plugin': 5.40.1_ghcq2hxpzlnfizbnoz3v5uflw4
-      '@typescript-eslint/parser': 5.40.1_yqf6kl63nyoq5megxukfnom5rm
+      '@typescript-eslint/eslint-plugin': 5.40.1_xjfekjuoddwwutqimm6dkbxj6m
+      '@typescript-eslint/parser': 5.40.1_eupmungbvhwcvwehlcd3ix3awy
       eslint: 8.23.0
-      typescript: 4.8.2
+      typescript: /@typescript-deploys/pr-build/4.2.0-pr-40468-44
     dev: true
 
   /eslint-config-xo/0.42.0_eslint@8.23.0:
@@ -2388,7 +2394,7 @@ packages:
       eslint-import-resolver-webpack:
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 5.40.1_yqf6kl63nyoq5megxukfnom5rm
+      '@typescript-eslint/parser': 5.40.1_eupmungbvhwcvwehlcd3ix3awy
       debug: 3.2.7
       eslint: 8.23.0
       eslint-import-resolver-node: 0.3.6
@@ -2416,7 +2422,7 @@ packages:
       - supports-color
     dev: true
 
-  /eslint-plugin-functional/4.4.1_yqf6kl63nyoq5megxukfnom5rm:
+  /eslint-plugin-functional/4.4.1_eupmungbvhwcvwehlcd3ix3awy:
     resolution: {integrity: sha512-YhSfHS52Si62Sn126g9wGx+XnWMoWhwEt6ctVXfcJj+xMUiggjOqUVMca7fuLNzX8jYiNBIeU1Y0teHGePZ3NA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -2429,12 +2435,12 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/utils': 5.40.1_yqf6kl63nyoq5megxukfnom5rm
+      '@typescript-eslint/utils': 5.40.1_eupmungbvhwcvwehlcd3ix3awy
       deepmerge-ts: 4.2.2
       escape-string-regexp: 4.0.0
       eslint: 8.23.0
       semver: 7.3.8
-      typescript: 4.8.2
+      typescript: /@typescript-deploys/pr-build/4.2.0-pr-40468-44
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -2449,7 +2455,7 @@ packages:
       '@typescript-eslint/parser':
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 5.40.1_yqf6kl63nyoq5megxukfnom5rm
+      '@typescript-eslint/parser': 5.40.1_eupmungbvhwcvwehlcd3ix3awy
       array-includes: 3.1.5
       array.prototype.flat: 1.3.0
       debug: 2.6.9
@@ -2470,7 +2476,7 @@ packages:
       - supports-color
     dev: true
 
-  /eslint-plugin-jest/27.1.3_qjdmv3cldmh7c4honmmroynun4:
+  /eslint-plugin-jest/27.1.3_nvhyk2cspxnmeccbndnurosy4a:
     resolution: {integrity: sha512-7DrIfYRQPa7JQd1Le8G/BJsfYHVUKQdJQ/6vULSp/4NjKZmSMJ/605G2hhScEra++SiH68zPEjLnrO74nHrMLg==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     peerDependencies:
@@ -2483,8 +2489,8 @@ packages:
       jest:
         optional: true
     dependencies:
-      '@typescript-eslint/eslint-plugin': 5.40.1_ghcq2hxpzlnfizbnoz3v5uflw4
-      '@typescript-eslint/utils': 5.40.1_yqf6kl63nyoq5megxukfnom5rm
+      '@typescript-eslint/eslint-plugin': 5.40.1_xjfekjuoddwwutqimm6dkbxj6m
+      '@typescript-eslint/utils': 5.40.1_eupmungbvhwcvwehlcd3ix3awy
       eslint: 8.23.0
       jest: 28.1.3
     transitivePeerDependencies:
@@ -2514,23 +2520,23 @@ packages:
       semver: 6.3.0
     dev: true
 
-  /eslint-plugin-mmkal/0.0.1-2_njvpd7oexm4jrpqkdx4xx3mxbm:
+  /eslint-plugin-mmkal/0.0.1-2_yhp3vwibthsaghedlibvwbska4:
     resolution: {integrity: sha512-/nmHcVuvdNtX3bxSQ/McZXRZf4smf3eUbz/6Z/gbRtkufMBTjyIzNsFJb0aV5fIuroxFauqA2TNqPc8DlQQmgQ==}
     dependencies:
-      '@rushstack/eslint-config': 3.1.1_yqf6kl63nyoq5megxukfnom5rm
-      '@rushstack/eslint-plugin': 0.10.0_yqf6kl63nyoq5megxukfnom5rm
-      '@rushstack/eslint-plugin-packlets': 0.5.0_yqf6kl63nyoq5megxukfnom5rm
-      '@rushstack/eslint-plugin-security': 0.4.0_yqf6kl63nyoq5megxukfnom5rm
+      '@rushstack/eslint-config': 3.1.1_eupmungbvhwcvwehlcd3ix3awy
+      '@rushstack/eslint-plugin': 0.10.0_eupmungbvhwcvwehlcd3ix3awy
+      '@rushstack/eslint-plugin-packlets': 0.5.0_eupmungbvhwcvwehlcd3ix3awy
+      '@rushstack/eslint-plugin-security': 0.4.0_eupmungbvhwcvwehlcd3ix3awy
       '@types/eslint': 8.4.7
-      '@typescript-eslint/eslint-plugin': 5.40.1_ghcq2hxpzlnfizbnoz3v5uflw4
-      '@typescript-eslint/parser': 5.40.1_yqf6kl63nyoq5megxukfnom5rm
+      '@typescript-eslint/eslint-plugin': 5.40.1_xjfekjuoddwwutqimm6dkbxj6m
+      '@typescript-eslint/parser': 5.40.1_eupmungbvhwcvwehlcd3ix3awy
       eslint-config-xo: 0.42.0_eslint@8.23.0
       eslint-config-xo-react: 0.27.0_4obl5svsfbt6nzqvqzeno5erv4
-      eslint-config-xo-typescript: 0.53.0_yqruj2vud6favyjjbpx7uotp7a
+      eslint-config-xo-typescript: 0.53.0_7x6kqayz46ejm635qzzwiuh6km
       eslint-plugin-codegen: 0.16.1
-      eslint-plugin-functional: 4.4.1_yqf6kl63nyoq5megxukfnom5rm
+      eslint-plugin-functional: 4.4.1_eupmungbvhwcvwehlcd3ix3awy
       eslint-plugin-import: 2.26.0_wyz7qklltnlaqz4spn62k7idzq
-      eslint-plugin-jest: 27.1.3_qjdmv3cldmh7c4honmmroynun4
+      eslint-plugin-jest: 27.1.3_nvhyk2cspxnmeccbndnurosy4a
       eslint-plugin-jsx-a11y: 6.6.1_eslint@8.23.0
       eslint-plugin-prettier: 4.2.1_bxpuzolsxufkw2ipnoyzzxnyrm
       eslint-plugin-promise: 6.1.1_eslint@8.23.0
@@ -5765,7 +5771,7 @@ packages:
     engines: {node: '>=8'}
     dev: true
 
-  /ts-jest/28.0.8_556mfp7b5dutuj2jcrj5i7zc5q:
+  /ts-jest/28.0.8_oxbhxmmeuefahdnbgyz5vo3yqq:
     resolution: {integrity: sha512-5FaG0lXmRPzApix8oFG8RKjAz4ehtm8yMKOTy5HX3fY6W8kmvOrmcY0hKDElW52FJov+clhUbrKAqofnj4mXTg==}
     engines: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
     hasBin: true
@@ -5794,7 +5800,7 @@ packages:
       lodash.memoize: 4.1.2
       make-error: 1.3.6
       semver: 7.3.8
-      typescript: 4.8.2
+      typescript: /@typescript-deploys/pr-build/4.2.0-pr-40468-44
       yargs-parser: 21.1.1
     dev: true
 
@@ -5811,14 +5817,14 @@ packages:
     resolution: {integrity: sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==}
     dev: true
 
-  /tsutils/3.21.0_typescript@4.8.2:
+  /tsutils/3.21.0_w3becoyqwjurswhufoizdhlxii:
     resolution: {integrity: sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==}
     engines: {node: '>= 6'}
     peerDependencies:
       typescript: '>=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta'
     dependencies:
       tslib: 1.14.1
-      typescript: 4.8.2
+      typescript: /@typescript-deploys/pr-build/4.2.0-pr-40468-44
     dev: true
 
   /type-check/0.4.0:
@@ -5872,12 +5878,6 @@ packages:
     resolution: {integrity: sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==}
     dependencies:
       is-typedarray: 1.0.0
-    dev: true
-
-  /typescript/4.8.2:
-    resolution: {integrity: sha512-C0I1UsrrDHo2fYI5oaCGbSejwX4ch+9Y5jTQELvovfmFkK3HHSZJB8MSJcWLmCUBzQBchCrZ9rMRV6GuNrvGtw==}
-    engines: {node: '>=4.2.0'}
-    hasBin: true
     dev: true
 
   /unbox-primitive/1.0.2:


### PR DESCRIPTION
Update Oct 2023:

I'm going to close this since #16 improves error messages and the [TypeScript PR was closed](https://github.com/microsoft/TypeScript/pull/40468#issuecomment-1670705761).

Copy-paste of https://github.com/mmkal/ts/pull/152

Note - since this is a copy paste of a mod of an old version, a few features that have gone in since then may be regressed. This isn't going to go in  anyway unless throw-types are added to TypeScript officially though.

---

original pr body

depends on https://github.com/microsoft/TypeScript/pull/40468

Error messages before:
![image](https://user-images.githubusercontent.com/15040698/93005714-a6d62780-f521-11ea-8da2-17783b59ac80.png)

Error messages after:
![image](https://user-images.githubusercontent.com/15040698/93005723-b5bcda00-f521-11ea-9161-3c1a5a2fa22c.png)