### PR TITLE
Update DeepBrand to improve type checking capabilities

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -36,6 +36,11 @@ export type DeepBrand<T> = IsNever<T> extends true
       type: 'constructor'
       params: ConstructorParams<T>
       instance: DeepBrand<InstanceType<Extract<T, new (...args: any) => any>>>
+      readonly: ReadonlyKeys<T>
+      required: RequiredKeys<T>
+      optional: OptionalKeys<T>
+      value: T
+      properties: {[K in keyof T]: DeepBrand<T[K]>}
     }
   : T extends (...args: infer P) => infer R // avoid functions with different params/return values matching
   ? {
@@ -43,19 +48,29 @@ export type DeepBrand<T> = IsNever<T> extends true
       params: DeepBrand<P>
       return: DeepBrand<R>
       this: DeepBrand<ThisParameterType<T>>
+      readonly: ReadonlyKeys<T>
+      required: RequiredKeys<T>
+      optional: OptionalKeys<T>
+      value: T
+      properties: {[K in keyof T]: DeepBrand<T[K]>}
     }
   : T extends any[]
   ? {
       type: 'array'
-      items: {[K in keyof T]: T[K]}
+      readonly: ReadonlyKeys<T>
+      required: RequiredKeys<T>
+      optional: OptionalKeys<T>
+      value: T
+      properties: {[K in keyof T]: DeepBrand<T[K]>}
     }
   : {
       type: 'object'
-      properties: {[K in keyof T]: DeepBrand<T[K]>}
       readonly: ReadonlyKeys<T>
       required: RequiredKeys<T>
       optional: OptionalKeys<T>
       constructorParams: DeepBrand<ConstructorParams<T>>
+      value: T
+      properties: {[K in keyof T]: DeepBrand<T[K]>}
     }
 
 export type RequiredKeys<T> = Extract<

--- a/test/errors.test.ts
+++ b/test/errors.test.ts
@@ -18,8 +18,8 @@ test('toEqualTypeOf<...>() error message', async () => {
     3 expectTypeOf({a: 1}).toEqualTypeOf<{a: string}>()
                            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-      src/index.ts:118:16
-        118     <Expected>(...MISMATCH: MismatchArgs<Equal<Actual, Expected>, B>): true
+      src/index.ts:133:16
+        133     <Expected>(...MISMATCH: MismatchArgs<Equal<Actual, Expected>, B>): true
                            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
         Arguments for the rest parameter 'MISMATCH' were not provided.
     "
@@ -43,8 +43,8 @@ test('toMatchTypeOf<...>() error message', async () => {
     3 expectTypeOf({a: 1}).toMatchTypeOf<{a: string}>()
                            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-      src/index.ts:114:16
-        114     <Expected>(...MISMATCH: MismatchArgs<Extends<Actual, Expected>, B>): true
+      src/index.ts:129:16
+        129     <Expected>(...MISMATCH: MismatchArgs<Extends<Actual, Expected>, B>): true
                            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
         Arguments for the rest parameter 'MISMATCH' were not provided.
     "
@@ -58,8 +58,8 @@ test('toMatchTypeOf(...) error message', async () => {
     3 expectTypeOf({a: 1}).toMatchTypeOf({a: 'one'})
                            ~~~~~~~~~~~~~~~~~~~~~~~~~
 
-      src/index.ts:115:36
-        115     <Expected>(expected: Expected, ...MISMATCH: MismatchArgs<Extends<Actual, Expected>, B>): true
+      src/index.ts:130:36
+        130     <Expected>(expected: Expected, ...MISMATCH: MismatchArgs<Extends<Actual, Expected>, B>): true
                                                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
         Arguments for the rest parameter 'MISMATCH' were not provided.
     "
@@ -86,8 +86,8 @@ test('usage test', () => {
     21   expectTypeOf({a: 1, b: 1}).toEqualTypeOf<{a: number}>()
                                     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-      src/index.ts:118:16
-        118     <Expected>(...MISMATCH: MismatchArgs<Equal<Actual, Expected>, B>): true
+      src/index.ts:133:16
+        133     <Expected>(...MISMATCH: MismatchArgs<Equal<Actual, Expected>, B>): true
                            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
         Arguments for the rest parameter 'MISMATCH' were not provided.
     test/usage.test.ts:35:25 - error TS2554: Expected 1 arguments, but got 0.
@@ -95,8 +95,8 @@ test('usage test', () => {
     35   expectTypeOf<Fruit>().toMatchTypeOf<Apple>()
                                ~~~~~~~~~~~~~~~~~~~~~~
 
-      src/index.ts:114:16
-        114     <Expected>(...MISMATCH: MismatchArgs<Extends<Actual, Expected>, B>): true
+      src/index.ts:129:16
+        129     <Expected>(...MISMATCH: MismatchArgs<Extends<Actual, Expected>, B>): true
                            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
         Arguments for the rest parameter 'MISMATCH' were not provided.
     test/usage.test.ts:38:25 - error TS2554: Expected 1 arguments, but got 0.
@@ -104,8 +104,8 @@ test('usage test', () => {
     38   expectTypeOf<Apple>().toEqualTypeOf<Fruit>()
                                ~~~~~~~~~~~~~~~~~~~~~~
 
-      src/index.ts:118:16
-        118     <Expected>(...MISMATCH: MismatchArgs<Equal<Actual, Expected>, B>): true
+      src/index.ts:133:16
+        133     <Expected>(...MISMATCH: MismatchArgs<Equal<Actual, Expected>, B>): true
                            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
         Arguments for the rest parameter 'MISMATCH' were not provided.
     test/usage.test.ts:42:24 - error TS2554: Expected 2 arguments, but got 1.
@@ -113,8 +113,8 @@ test('usage test', () => {
     42   expectTypeOf({a: 1}).toMatchTypeOf({b: 1})
                               ~~~~~~~~~~~~~~~~~~~~~
 
-      src/index.ts:115:36
-        115     <Expected>(expected: Expected, ...MISMATCH: MismatchArgs<Extends<Actual, Expected>, B>): true
+      src/index.ts:130:36
+        130     <Expected>(expected: Expected, ...MISMATCH: MismatchArgs<Extends<Actual, Expected>, B>): true
                                                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
         Arguments for the rest parameter 'MISMATCH' were not provided.
     test/usage.test.ts:51:25 - error TS2554: Expected 1 arguments, but got 0.
@@ -122,8 +122,8 @@ test('usage test', () => {
     51   expectTypeOf<Fruit>().toMatchTypeOf<Apple>()
                                ~~~~~~~~~~~~~~~~~~~~~~
 
-      src/index.ts:114:16
-        114     <Expected>(...MISMATCH: MismatchArgs<Extends<Actual, Expected>, B>): true
+      src/index.ts:129:16
+        129     <Expected>(...MISMATCH: MismatchArgs<Extends<Actual, Expected>, B>): true
                            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
         Arguments for the rest parameter 'MISMATCH' were not provided.
     test/usage.test.ts:52:25 - error TS2554: Expected 1 arguments, but got 0.
@@ -131,8 +131,8 @@ test('usage test', () => {
     52   expectTypeOf<Apple>().toEqualTypeOf<Fruit>()
                                ~~~~~~~~~~~~~~~~~~~~~~
 
-      src/index.ts:118:16
-        118     <Expected>(...MISMATCH: MismatchArgs<Equal<Actual, Expected>, B>): true
+      src/index.ts:133:16
+        133     <Expected>(...MISMATCH: MismatchArgs<Equal<Actual, Expected>, B>): true
                            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
         Arguments for the rest parameter 'MISMATCH' were not provided.
     test/usage.test.ts:61:25 - error TS2554: Expected 1 arguments, but got 0.
@@ -140,8 +140,8 @@ test('usage test', () => {
     61   expectTypeOf<never>().toBeNumber()
                                ~~~~~~~~~~~~
 
-      src/index.ts:105:16
-        105   toBeNumber: (...MISMATCH: MismatchArgs<Extends<Actual, number>, B>) => true
+      src/index.ts:120:16
+        120   toBeNumber: (...MISMATCH: MismatchArgs<Extends<Actual, number>, B>) => true
                            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
         Arguments for the rest parameter 'MISMATCH' were not provided.
     test/usage.test.ts:65:43 - error TS2554: Expected 1 arguments, but got 0.
@@ -149,8 +149,8 @@ test('usage test', () => {
     65   expectTypeOf<{deeply: {nested: any}}>().toEqualTypeOf<{deeply: {nested: unknown}}>()
                                                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-      src/index.ts:118:16
-        118     <Expected>(...MISMATCH: MismatchArgs<Equal<Actual, Expected>, B>): true
+      src/index.ts:133:16
+        133     <Expected>(...MISMATCH: MismatchArgs<Equal<Actual, Expected>, B>): true
                            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
         Arguments for the rest parameter 'MISMATCH' were not provided.
     test/usage.test.ts:83:27 - error TS2554: Expected 1 arguments, but got 0.
@@ -158,8 +158,8 @@ test('usage test', () => {
     83   expectTypeOf(undefined).toBeNullable()
                                  ~~~~~~~~~~~~~~
 
-      src/index.ts:112:18
-        112   toBeNullable: (...MISMATCH: MismatchArgs<Not<Equal<Actual, NonNullable<Actual>>>, B>) => true
+      src/index.ts:127:18
+        127   toBeNullable: (...MISMATCH: MismatchArgs<Not<Equal<Actual, NonNullable<Actual>>>, B>) => true
                              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
         Arguments for the rest parameter 'MISMATCH' were not provided.
     test/usage.test.ts:87:22 - error TS2554: Expected 1 arguments, but got 0.
@@ -167,8 +167,8 @@ test('usage test', () => {
     87   expectTypeOf(null).toBeNullable()
                             ~~~~~~~~~~~~~~
 
-      src/index.ts:112:18
-        112   toBeNullable: (...MISMATCH: MismatchArgs<Not<Equal<Actual, NonNullable<Actual>>>, B>) => true
+      src/index.ts:127:18
+        127   toBeNullable: (...MISMATCH: MismatchArgs<Not<Equal<Actual, NonNullable<Actual>>>, B>) => true
                              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
         Arguments for the rest parameter 'MISMATCH' were not provided.
     test/usage.test.ts:90:33 - error TS2554: Expected 1 arguments, but got 0.
@@ -176,8 +176,8 @@ test('usage test', () => {
     90   expectTypeOf<1 | undefined>().toBeNullable()
                                        ~~~~~~~~~~~~~~
 
-      src/index.ts:112:18
-        112   toBeNullable: (...MISMATCH: MismatchArgs<Not<Equal<Actual, NonNullable<Actual>>>, B>) => true
+      src/index.ts:127:18
+        127   toBeNullable: (...MISMATCH: MismatchArgs<Not<Equal<Actual, NonNullable<Actual>>>, B>) => true
                              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
         Arguments for the rest parameter 'MISMATCH' were not provided.
     test/usage.test.ts:91:28 - error TS2554: Expected 1 arguments, but got 0.
@@ -185,8 +185,8 @@ test('usage test', () => {
     91   expectTypeOf<1 | null>().toBeNullable()
                                   ~~~~~~~~~~~~~~
 
-      src/index.ts:112:18
-        112   toBeNullable: (...MISMATCH: MismatchArgs<Not<Equal<Actual, NonNullable<Actual>>>, B>) => true
+      src/index.ts:127:18
+        127   toBeNullable: (...MISMATCH: MismatchArgs<Not<Equal<Actual, NonNullable<Actual>>>, B>) => true
                              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
         Arguments for the rest parameter 'MISMATCH' were not provided.
     test/usage.test.ts:92:40 - error TS2554: Expected 1 arguments, but got 0.
@@ -194,8 +194,8 @@ test('usage test', () => {
     92   expectTypeOf<1 | undefined | null>().toBeNullable()
                                               ~~~~~~~~~~~~~~
 
-      src/index.ts:112:18
-        112   toBeNullable: (...MISMATCH: MismatchArgs<Not<Equal<Actual, NonNullable<Actual>>>, B>) => true
+      src/index.ts:127:18
+        127   toBeNullable: (...MISMATCH: MismatchArgs<Not<Equal<Actual, NonNullable<Actual>>>, B>) => true
                              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
         Arguments for the rest parameter 'MISMATCH' were not provided.
     test/usage.test.ts:96:19 - error TS2554: Expected 1 arguments, but got 0.
@@ -203,8 +203,8 @@ test('usage test', () => {
     96   expectTypeOf(1).toBeUnknown()
                          ~~~~~~~~~~~~~
 
-      src/index.ts:100:17
-        100   toBeUnknown: (...MISMATCH: MismatchArgs<IsUnknown<Actual>, B>) => true
+      src/index.ts:115:17
+        115   toBeUnknown: (...MISMATCH: MismatchArgs<IsUnknown<Actual>, B>) => true
                             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
         Arguments for the rest parameter 'MISMATCH' were not provided.
     test/usage.test.ts:97:19 - error TS2554: Expected 1 arguments, but got 0.
@@ -212,17 +212,17 @@ test('usage test', () => {
     97   expectTypeOf(1).toBeAny()
                          ~~~~~~~~~
 
-      src/index.ts:99:13
-        99   toBeAny: (...MISMATCH: MismatchArgs<IsAny<Actual>, B>) => true
-                       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      src/index.ts:114:13
+        114   toBeAny: (...MISMATCH: MismatchArgs<IsAny<Actual>, B>) => true
+                        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
         Arguments for the rest parameter 'MISMATCH' were not provided.
     test/usage.test.ts:98:19 - error TS2554: Expected 1 arguments, but got 0.
 
     98   expectTypeOf(1).toBeNever()
                          ~~~~~~~~~~~
 
-      src/index.ts:101:15
-        101   toBeNever: (...MISMATCH: MismatchArgs<IsNever<Actual>, B>) => true
+      src/index.ts:116:15
+        116   toBeNever: (...MISMATCH: MismatchArgs<IsNever<Actual>, B>) => true
                           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
         Arguments for the rest parameter 'MISMATCH' were not provided.
     test/usage.test.ts:99:19 - error TS2554: Expected 1 arguments, but got 0.
@@ -230,8 +230,8 @@ test('usage test', () => {
     99   expectTypeOf(1).toBeNull()
                          ~~~~~~~~~~
 
-      src/index.ts:110:14
-        110   toBeNull: (...MISMATCH: MismatchArgs<Extends<Actual, null>, B>) => true
+      src/index.ts:125:14
+        125   toBeNull: (...MISMATCH: MismatchArgs<Extends<Actual, null>, B>) => true
                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
         Arguments for the rest parameter 'MISMATCH' were not provided.
     test/usage.test.ts:100:19 - error TS2554: Expected 1 arguments, but got 0.
@@ -239,8 +239,8 @@ test('usage test', () => {
     100   expectTypeOf(1).toBeUndefined()
                           ~~~~~~~~~~~~~~~
 
-      src/index.ts:111:19
-        111   toBeUndefined: (...MISMATCH: MismatchArgs<Extends<Actual, undefined>, B>) => true
+      src/index.ts:126:19
+        126   toBeUndefined: (...MISMATCH: MismatchArgs<Extends<Actual, undefined>, B>) => true
                               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
         Arguments for the rest parameter 'MISMATCH' were not provided.
     test/usage.test.ts:101:19 - error TS2554: Expected 1 arguments, but got 0.
@@ -248,8 +248,8 @@ test('usage test', () => {
     101   expectTypeOf(1).toBeNullable()
                           ~~~~~~~~~~~~~~
 
-      src/index.ts:112:18
-        112   toBeNullable: (...MISMATCH: MismatchArgs<Not<Equal<Actual, NonNullable<Actual>>>, B>) => true
+      src/index.ts:127:18
+        127   toBeNullable: (...MISMATCH: MismatchArgs<Not<Equal<Actual, NonNullable<Actual>>>, B>) => true
                              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
         Arguments for the rest parameter 'MISMATCH' were not provided.
     test/usage.test.ts:106:35 - error TS2554: Expected 1 arguments, but got 0.
@@ -257,8 +257,8 @@ test('usage test', () => {
     106   expectTypeOf<string | number>().toMatchTypeOf<number>()
                                           ~~~~~~~~~~~~~~~~~~~~~~~
 
-      src/index.ts:114:16
-        114     <Expected>(...MISMATCH: MismatchArgs<Extends<Actual, Expected>, B>): true
+      src/index.ts:129:16
+        129     <Expected>(...MISMATCH: MismatchArgs<Extends<Actual, Expected>, B>): true
                            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
         Arguments for the rest parameter 'MISMATCH' were not provided.
     test/usage.test.ts:130:71 - error TS2554: Expected 2 arguments, but got 1.
@@ -266,8 +266,8 @@ test('usage test', () => {
     130   expectTypeOf<ResponsiveProp<number>>().exclude<number | number[]>().toHaveProperty('xxl')
                                                                               ~~~~~~~~~~~~~~~~~~~~~
 
-      src/index.ts:125:5
-        125     ...MISMATCH: MismatchArgs<Extends<K, keyof Actual>, B>
+      src/index.ts:140:5
+        140     ...MISMATCH: MismatchArgs<Extends<K, keyof Actual>, B>
                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
         Arguments for the rest parameter 'MISMATCH' were not provided.
     test/usage.test.ts:147:21 - error TS2554: Expected 2 arguments, but got 1.
@@ -275,8 +275,8 @@ test('usage test', () => {
     147   expectTypeOf(obj).toHaveProperty('c')
                             ~~~~~~~~~~~~~~~~~~~
 
-      src/index.ts:125:5
-        125     ...MISMATCH: MismatchArgs<Extends<K, keyof Actual>, B>
+      src/index.ts:140:5
+        140     ...MISMATCH: MismatchArgs<Extends<K, keyof Actual>, B>
                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
         Arguments for the rest parameter 'MISMATCH' were not provided.
     test/usage.test.ts:152:41 - error TS2554: Expected 1 arguments, but got 0.
@@ -284,8 +284,8 @@ test('usage test', () => {
     152   expectTypeOf(obj).toHaveProperty('a').toBeString()
                                                 ~~~~~~~~~~~~
 
-      src/index.ts:106:16
-        106   toBeString: (...MISMATCH: MismatchArgs<Extends<Actual, string>, B>) => true
+      src/index.ts:121:16
+        121   toBeString: (...MISMATCH: MismatchArgs<Extends<Actual, string>, B>) => true
                            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
         Arguments for the rest parameter 'MISMATCH' were not provided.
     test/usage.test.ts:159:27 - error TS2554: Expected 1 arguments, but got 0.
@@ -293,8 +293,8 @@ test('usage test', () => {
     159   expectTypeOf<NoParam>().toEqualTypeOf<HasParam>()
                                   ~~~~~~~~~~~~~~~~~~~~~~~~~
 
-      src/index.ts:118:16
-        118     <Expected>(...MISMATCH: MismatchArgs<Equal<Actual, Expected>, B>): true
+      src/index.ts:133:16
+        133     <Expected>(...MISMATCH: MismatchArgs<Equal<Actual, Expected>, B>): true
                            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
         Arguments for the rest parameter 'MISMATCH' were not provided.
     test/usage.test.ts:179:19 - error TS2554: Expected 1 arguments, but got 0.
@@ -302,18 +302,18 @@ test('usage test', () => {
     179   expectTypeOf(f).toBeAny()
                           ~~~~~~~~~
 
-      src/index.ts:99:13
-        99   toBeAny: (...MISMATCH: MismatchArgs<IsAny<Actual>, B>) => true
-                       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      src/index.ts:114:13
+        114   toBeAny: (...MISMATCH: MismatchArgs<IsAny<Actual>, B>) => true
+                        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
         Arguments for the rest parameter 'MISMATCH' were not provided.
     test/usage.test.ts:180:27 - error TS2554: Expected 1 arguments, but got 0.
 
     180   expectTypeOf(f).returns.toBeAny()
                                   ~~~~~~~~~
 
-      src/index.ts:99:13
-        99   toBeAny: (...MISMATCH: MismatchArgs<IsAny<Actual>, B>) => true
-                       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      src/index.ts:114:13
+        114   toBeAny: (...MISMATCH: MismatchArgs<IsAny<Actual>, B>) => true
+                        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
         Arguments for the rest parameter 'MISMATCH' were not provided.
     test/usage.test.ts:183:46 - error TS2345: Argument of type 'string' is not assignable to parameter of type 'never'.
 
@@ -328,8 +328,8 @@ test('usage test', () => {
     246   expectTypeOf([1, 2, 3]).items.toBeString()
                                         ~~~~~~~~~~~~
 
-      src/index.ts:106:16
-        106   toBeString: (...MISMATCH: MismatchArgs<Extends<Actual, string>, B>) => true
+      src/index.ts:121:16
+        121   toBeString: (...MISMATCH: MismatchArgs<Extends<Actual, string>, B>) => true
                            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
         Arguments for the rest parameter 'MISMATCH' were not provided.
     test/usage.test.ts:258:31 - error TS2554: Expected 1 arguments, but got 0.
@@ -337,8 +337,8 @@ test('usage test', () => {
     258   expectTypeOf<{a: string}>().toEqualTypeOf<{a: number}>()
                                       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-      src/index.ts:118:16
-        118     <Expected>(...MISMATCH: MismatchArgs<Equal<Actual, Expected>, B>): true
+      src/index.ts:133:16
+        133     <Expected>(...MISMATCH: MismatchArgs<Equal<Actual, Expected>, B>): true
                            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
         Arguments for the rest parameter 'MISMATCH' were not provided.
     test/usage.test.ts:263:32 - error TS2554: Expected 1 arguments, but got 0.
@@ -346,8 +346,8 @@ test('usage test', () => {
     263   expectTypeOf<{a?: number}>().toEqualTypeOf<{a: number}>()
                                        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-      src/index.ts:118:16
-        118     <Expected>(...MISMATCH: MismatchArgs<Equal<Actual, Expected>, B>): true
+      src/index.ts:133:16
+        133     <Expected>(...MISMATCH: MismatchArgs<Equal<Actual, Expected>, B>): true
                            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
         Arguments for the rest parameter 'MISMATCH' were not provided.
     test/usage.test.ts:264:32 - error TS2554: Expected 1 arguments, but got 0.
@@ -355,8 +355,8 @@ test('usage test', () => {
     264   expectTypeOf<{a?: number}>().toEqualTypeOf<{a: number | undefined}>()
                                        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-      src/index.ts:118:16
-        118     <Expected>(...MISMATCH: MismatchArgs<Equal<Actual, Expected>, B>): true
+      src/index.ts:133:16
+        133     <Expected>(...MISMATCH: MismatchArgs<Equal<Actual, Expected>, B>): true
                            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
         Arguments for the rest parameter 'MISMATCH' were not provided.
     test/usage.test.ts:265:39 - error TS2554: Expected 1 arguments, but got 0.
@@ -364,8 +364,8 @@ test('usage test', () => {
     265   expectTypeOf<{a?: number | null}>().toEqualTypeOf<{a: number | null}>()
                                               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-      src/index.ts:118:16
-        118     <Expected>(...MISMATCH: MismatchArgs<Equal<Actual, Expected>, B>): true
+      src/index.ts:133:16
+        133     <Expected>(...MISMATCH: MismatchArgs<Equal<Actual, Expected>, B>): true
                            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
         Arguments for the rest parameter 'MISMATCH' were not provided.
     test/usage.test.ts:274:22 - error TS2554: Expected 1 arguments, but got 0.
@@ -373,8 +373,8 @@ test('usage test', () => {
     274   expectTypeOf<A1>().toEqualTypeOf<E1>()
                              ~~~~~~~~~~~~~~~~~~~
 
-      src/index.ts:118:16
-        118     <Expected>(...MISMATCH: MismatchArgs<Equal<Actual, Expected>, B>): true
+      src/index.ts:133:16
+        133     <Expected>(...MISMATCH: MismatchArgs<Equal<Actual, Expected>, B>): true
                            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
         Arguments for the rest parameter 'MISMATCH' were not provided.
     test/usage.test.ts:280:22 - error TS2554: Expected 1 arguments, but got 0.
@@ -382,8 +382,8 @@ test('usage test', () => {
     280   expectTypeOf<A2>().toEqualTypeOf<E2>()
                              ~~~~~~~~~~~~~~~~~~~
 
-      src/index.ts:118:16
-        118     <Expected>(...MISMATCH: MismatchArgs<Equal<Actual, Expected>, B>): true
+      src/index.ts:133:16
+        133     <Expected>(...MISMATCH: MismatchArgs<Equal<Actual, Expected>, B>): true
                            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
         Arguments for the rest parameter 'MISMATCH' were not provided.
     test/usage.test.ts:297:28 - error TS2554: Expected 1 arguments, but got 0.
@@ -391,8 +391,8 @@ test('usage test', () => {
     297   expectTypeOf<typeof A>().toEqualTypeOf<typeof B>()
                                    ~~~~~~~~~~~~~~~~~~~~~~~~~
 
-      src/index.ts:118:16
-        118     <Expected>(...MISMATCH: MismatchArgs<Equal<Actual, Expected>, B>): true
+      src/index.ts:133:16
+        133     <Expected>(...MISMATCH: MismatchArgs<Equal<Actual, Expected>, B>): true
                            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
         Arguments for the rest parameter 'MISMATCH' were not provided.
     "

--- a/test/types.test.ts
+++ b/test/types.test.ts
@@ -189,3 +189,160 @@ test(`undefined isn't removed from unions`, () => {
   expectTypeOf<string | null | undefined>().toEqualTypeOf<string | null | undefined>()
   expectTypeOf<string | null | undefined>().toMatchTypeOf<string | null | undefined>()
 })
+
+// Note: Works because of DeepBrand `type: 'function'` properties `params` and `return`.
+test('Distinguish between functions whose return types differ by readonly prop', () => {
+  type A1 = {readonly x: number}
+  type B1 = {x: number}
+
+  function f(a1: A1): A1 {
+    return a1
+  }
+
+  function g(b1: B1): B1 {
+    return b1
+  }
+
+  expectTypeOf<typeof f>().not.toEqualTypeOf<typeof g>()
+})
+
+// Note: Works because of DeepBrand `type: 'object'` property `value`.
+test('Distinguish between classes with only private properties', () => {
+  class A {
+    // eslint-disable-next-line mmkal/@typescript-eslint/class-literal-property-style
+    private readonly a = 1
+  }
+
+  class B {
+    // eslint-disable-next-line mmkal/@typescript-eslint/class-literal-property-style
+    private readonly b = 1
+  }
+
+  expectTypeOf<A>().not.toEqualTypeOf<B>()
+})
+
+// Note: Works because of DeepBrand `type: 'function'` property `value`.
+test('Distinguish between types with generics used in type assertion', () => {
+  interface Guard<T> {
+    // eslint-disable-next-line mmkal/@typescript-eslint/prefer-function-type
+    (arg: unknown): arg is T
+  }
+
+  expectTypeOf<Guard<number>>().not.toEqualTypeOf<Guard<string>>()
+})
+
+// Note: Works because of DeepBrand `type: 'function'` property `value`.
+test('Distinguish between functions with generics vs unknown', () => {
+  function f<T>(p1: T, p2: T): T {
+    return p1 || p2
+  }
+
+  function g(p1: unknown, p2: unknown): unknown {
+    return p1 || p2
+  }
+
+  expectTypeOf<typeof f>().not.toEqualTypeOf<typeof g>()
+})
+
+// Note: Tests the functionality of various DeepBrand `type: 'function'` properties.
+test('Distinguish between functions with properties', () => {
+  interface BaseFunc {
+    // eslint-disable-next-line mmkal/@typescript-eslint/prefer-function-type
+    (str: string): number
+  }
+
+  interface ReadonlyDiffers1 extends BaseFunc {
+    readonly readonly: string
+  }
+
+  interface ReadonlyDiffers2 extends BaseFunc {
+    readonly: string
+  }
+
+  // Exercises the `readonly` property.
+  expectTypeOf<ReadonlyDiffers1>().not.toEqualTypeOf<ReadonlyDiffers2>()
+
+  interface OptionalDiffers1 extends BaseFunc {
+    optional?: number
+  }
+
+  interface OptionalDiffers2 extends BaseFunc {
+    optional: number | undefined
+  }
+
+  // Exercises the `optional` property (`properties` and `value` covers this as well)
+  expectTypeOf<OptionalDiffers1>().not.toEqualTypeOf<OptionalDiffers2>()
+
+  interface PropTypeDiffers1 extends BaseFunc {
+    prop: number
+  }
+
+  interface PropTypeDiffers2 extends BaseFunc {
+    prop: string
+  }
+
+  // Exercises the `properties` property (`value` covers this as well)
+  expectTypeOf<PropTypeDiffers1>().not.toEqualTypeOf<PropTypeDiffers2>()
+})
+
+// Note: Works because of DeepBrand `type: 'array'` property `properties`.
+test('Distinguish between tuples with differing values', () => {
+  type ReadonlyDiffers1 = [{prop: number}]
+  type ReadonlyDiffers2 = [{readonly prop: number}]
+
+  expectTypeOf<ReadonlyDiffers1>().not.toEqualTypeOf<ReadonlyDiffers2>()
+})
+
+// Note: Tests the functionality of various DeepBrand `type: 'array'` properties.
+test('Distinguish between array with properties', () => {
+  type ReadonlyDiffers1 = number[] & {prop: number}
+  type ReadonlyDiffers2 = number[] & {readonly prop: number}
+
+  // Exercises the `readonly` property.
+  expectTypeOf<ReadonlyDiffers1>().not.toEqualTypeOf<ReadonlyDiffers2>()
+})
+
+// Note: Tests the functionality of various DeepBrand `type: 'constructor'` properties.
+test('Distinguish between constructors with properties', () => {
+  interface Base {
+    someProp: number
+  }
+
+  interface BaseConstructor {
+    // eslint-disable-next-line mmkal/@typescript-eslint/prefer-function-type
+    new (str: string): Base
+  }
+
+  interface ReadonlyDiffers1 extends BaseConstructor {
+    readonly readonly: string
+  }
+
+  interface ReadonlyDiffers2 extends BaseConstructor {
+    readonly: string
+  }
+
+  // Exercises the `readonly` property.
+  expectTypeOf<ReadonlyDiffers1>().not.toEqualTypeOf<ReadonlyDiffers2>()
+
+  interface OptionalDiffers1 extends BaseConstructor {
+    optional?: number
+  }
+
+  interface OptionalDiffers2 extends BaseConstructor {
+    optional: number | undefined
+  }
+
+  // Exercises the `optional` property (`properties` and `value` covers this as well)
+  expectTypeOf<OptionalDiffers1>().not.toEqualTypeOf<OptionalDiffers2>()
+
+  interface PropTypeDiffers1 extends BaseConstructor {
+    prop: number
+  }
+
+  interface PropTypeDiffers2 extends BaseConstructor {
+    prop: string
+  }
+
+  // Exercises the `properties` property (`value` covers this as well)
+  expectTypeOf<PropTypeDiffers1>().not.toEqualTypeOf<PropTypeDiffers2>()
+})


### PR DESCRIPTION
Makes `DeepBrand` more comprehensive to cover more cases. See the updated `usage.test.ts` test cases to get an idea of what is supported now.

Most things in TypeScript can have properties attached to them. There are also some things that `DeepBrand` can only check for by just directly including `value: T` such as private properties on classes.