### PR TITLE
Prevent the .not modifier from being chained

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -143,7 +143,7 @@ export interface ExpectTypeOf<Actual, B extends boolean> {
       ? never
       : ExpectTypeOf<T, B>
     : never
-  not: ExpectTypeOf<Actual, Not<B>>
+  not: Omit<ExpectTypeOf<Actual, Not<B>>, 'not'>
 }
 const fn: any = () => true
 

--- a/test/types.test.ts
+++ b/test/types.test.ts
@@ -70,6 +70,11 @@ test(`never types don't sneak by`, () => {
   expectTypeOf<never>().toMatchTypeOf<{foo: string}>()
 })
 
+test('not cannot be chained', () => {
+  // @ts-expect-error
+  expectTypeOf<number>().not.not.toBeNumber()
+})
+
 test('constructor params', () => {
   // The built-in ConstructorParameters type helper fails to pick up no-argument overloads.
   // This test checks that's still the case to avoid unnecessarily maintaining a workaround,


### PR DESCRIPTION
Chaining `.not` more than once is non-sensical so there is little benefit to support chaining it.

It is suppressed via the built-in `Omit`.