### PR TITLE
Test against different versions of TypeScript during CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,10 +16,27 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ts: ['4.7', '4.8', '4.9', '5.0', '5.1', '5.2', '5.3', '5.4']
+        node: [20.x]
+        ts: [4.7, 4.8, 4.9, 5.0, 5.1, 5.2, 5.3, 5.4]
+
     steps:
-      - uses: actions/checkout@v4
-      - run: corepack enable
-      - run: pnpm install
-      - run: pnpm install typescript@${{ matrix.ts }}
-      - run: pnpm type-check
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js ${{ matrix.node }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node }}
+          cache: "pnpm"
+
+      - name: Enable Corepack
+        run: corepack enable
+
+      - name: Install Dependencies
+        run: pnpm install
+
+      - name: Install TypeScript Version ${{ matrix.ts }}
+        run: pnpm install typescript@${{ matrix.ts }}
+
+      - name: Test Types
+        run: pnpm type-check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,30 +14,13 @@ jobs:
 
   test-types:
     runs-on: ubuntu-latest
-    name: Test TypeScript Types with Node.js ${{ matrix.node }} and TypeScript ${{ matrix.ts }}
+    name: Test Types with TypeScript ${{ matrix.ts }}
     strategy:
       matrix:
-        node: [20.x]
         ts: [4.7, 4.8, 4.9, 5.0, 5.1, 5.2, 5.3, 5.4]
-
     steps:
-      - name: Checkout Repository
-        uses: actions/checkout@v4
-
-      - name: Enable Corepack
-        run: corepack enable
-
-      - name: Setup Node.js ${{ matrix.node }}
-        uses: actions/setup-node@v4
-        with:
-          node-version: ${{ matrix.node }}
-          cache: "pnpm"
-
-      - name: Install Dependencies
-        run: pnpm install
-
-      - name: Install TypeScript Version ${{ matrix.ts }}
-        run: pnpm install typescript@${{ matrix.ts }}
-
-      - name: Test Types
-        run: pnpm type-check
+      - uses: actions/checkout@v4
+      - run: corepack enable
+      - run: pnpm install
+      - run: pnpm install typescript@${{ matrix.ts }}
+      - run: pnpm type-check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,3 +34,16 @@ jobs:
           STATUS: '${{ fromJson(steps.coveragejson.outputs.result).pct }}%'
           COLOR: ${{ fromJson(steps.coveragejson.outputs.result).color }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  test-types:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        ts: ['4.7', '4.8', '4.9', '5.0', '5.1', '5.2', '5.3', '5.4']
+    steps:
+      - uses: actions/checkout@v4
+      - run: corepack enable
+      - run: pnpm install
+      - run: pnpm install typescript@${{ matrix.ts }}
+      - run: pnpm type-check
+

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,14 +23,14 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v4
 
+      - name: Enable Corepack
+        run: corepack enable
+
       - name: Setup Node.js ${{ matrix.node }}
         uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node }}
           cache: "pnpm"
-
-      - name: Enable Corepack
-        run: corepack enable
 
       - name: Install Dependencies
         run: pnpm install

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ jobs:
   run:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - run: corepack enable
       - run: pnpm install
       - run: pnpm run build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,5 @@
 name: CI
-on:
-  push: {}
-  pull_request: {}
+on: [push, pull_request]
 
 jobs:
   test:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,3 +11,15 @@ jobs:
       - run: pnpm run build
       - run: pnpm run lint
       - run: pnpm test
+
+  test-types:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        ts: ['4.7', '4.8', '4.9', '5.0', '5.1', '5.2', '5.3', '5.4']
+    steps:
+      - uses: actions/checkout@v4
+      - run: corepack enable
+      - run: pnpm install
+      - run: pnpm install typescript@${{ matrix.ts }}
+      - run: pnpm type-check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,7 @@ jobs:
 
   test-types:
     runs-on: ubuntu-latest
+    name: Test TypeScript Types with Node.js ${{ matrix.node }} and TypeScript ${{ matrix.ts }}
     strategy:
       matrix:
         node: [20.x]

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   ],
   "scripts": {
     "lint": "tsc && eslint .",
+    "type-check": "tsc",
     "build": "tsc -p tsconfig.lib.json",
     "test": "jest"
   },


### PR DESCRIPTION
## This PR:

  - [X] Adds `test-types` CI job to run `tsc` with different versions of TypeScript.
  - [X] Updates `actions/checkout` usages to v4.
  - [X] Resolves #60.