### PR TITLE
protect against any more

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,9 @@ See below for lots more examples.
 - [Documentation](#documentation)
    - [Features](#features)
    - [Why is my assertion failing?](#why-is-my-assertion-failing)
+   - [Special cases](#special-cases)
+      - [`any`](#any)
+   - [`never`](#never)
    - [Where is `.toExtend`?](#where-is-toextend)
    - [Internal type helpers](#internal-type-helpers)
    - [Error messages](#error-messages)
@@ -575,6 +578,16 @@ expectTypeOf<{a: {b: 1} & {c: 1}}>().toEqualTypeOf<{a: {b: 1; c: 1}}>()
 
 expectTypeOf<{a: {b: 1} & {c: 1}}>().branded.toEqualTypeOf<{a: {b: 1; c: 1}}>()
 ```
+
+### Special cases
+
+#### `any`
+
+While technically if you have a value with type `any`, you could pass it to a function which accepts a more specific type, in practice if you're using this library, it's assumed you're trying to avoid accidental `any`s creeping into your code. So, the only assertion available for the `any` type is `toBeAny()`.
+
+### `never`
+
+Similarly, `never` can have some unusual behaviour, so an assertion like `expectTypeOf<never>().toExtend<{a: 1}>()` fails, even though technically, `never` does extend `{a: 1}`.
 
 ### Where is `.toExtend`?
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ See below for lots more examples.
    - [Why is my assertion failing?](#why-is-my-assertion-failing)
    - [Special cases](#special-cases)
       - [`any`](#any)
-   - [`never`](#never)
+      - [`never`](#never)
    - [Where is `.toExtend`?](#where-is-toextend)
    - [Internal type helpers](#internal-type-helpers)
    - [Error messages](#error-messages)
@@ -585,13 +585,13 @@ expectTypeOf<{a: {b: 1} & {c: 1}}>().branded.toEqualTypeOf<{a: {b: 1; c: 1}}>()
 
 While technically if you have a value with type `any`, you could pass it to a function which accepts a more specific type, in practice if you're using this library, it's assumed you're trying to avoid accidental `any`s creeping into your code. So, the only assertion available for the `any` type is `toBeAny()`.
 
-### `never`
+#### `never`
 
-Similarly, `never` can have some unusual behaviour, so an assertion like `expectTypeOf<never>().toExtend<{a: 1}>()` fails, even though technically, `never` does extend `{a: 1}`.
+Similarly, `never` can have some unusual behaviour, so an assertion like `expectTypeOf<never>().toMatchTypeOf<{a: 1}>()` fails, even though technically, `never` does extend `{a: 1}`.
 
 ### Where is `.toExtend`?
 
-A few people have asked for a method like `toExtend` - this is essentially what `toMatchTypeOf` is. There are some cases where it doesn't _precisely_ match the `extends` operator in TypeScript, but for most practical use cases, you can think of this as the same thing.
+A few people have asked for a method like `toExtend` - this is essentially what `toMatchTypeOf` is. There are some cases like the above where it doesn't _precisely_ match the `extends` operator in TypeScript, but for most practical use cases, you can think of this as the same thing.
 
 ### Internal type helpers
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -353,9 +353,16 @@ type Scolder<
 
 /**
  * Represents the positive assertion methods available for type checking in the
+ * {@linkcode expectTypeOf()} utility. Is the `Actual` type is `any`, only the `toBeAny` assertion is available.
+ */
+export type PositiveExpectTypeOf<Actual> =
+  IsAny<Actual> extends true ? Pick<PositiveAssertions<Actual>, 'toBeAny'> : PositiveAssertions<Actual>
+
+/**
+ * Represents the positive assertion methods available for type checking in the
  * {@linkcode expectTypeOf()} utility.
  */
-export interface PositiveExpectTypeOf<Actual> extends BaseExpectTypeOf<Actual, {positive: true; branded: false}> {
+export interface PositiveAssertions<Actual> extends BaseExpectTypeOf<Actual, {positive: true; branded: false}> {
   toEqualTypeOf: {
     /**
      * Uses TypeScript's internal technique to check for type "identicalness".
@@ -740,7 +747,9 @@ export interface NegativeExpectTypeOf<Actual> extends BaseExpectTypeOf<Actual, {
  * on the value of the `positive` property in the {@linkcode Options} type.
  */
 export type ExpectTypeOf<Actual, Options extends {positive: boolean}> = Options['positive'] extends true
-  ? PositiveExpectTypeOf<Actual>
+  ? IsAny<Actual> extends true
+    ? Pick<PositiveExpectTypeOf<Actual>, 'toBeAny'>
+    : PositiveExpectTypeOf<Actual>
   : NegativeExpectTypeOf<Actual>
 
 /**
@@ -1200,7 +1209,7 @@ export const expectTypeOf: _ExpectTypeOf = <Actual>(
     'asserts',
     'branded',
   ] as const
-  type Keys = keyof PositiveExpectTypeOf<any> | keyof NegativeExpectTypeOf<any>
+  type Keys = keyof PositiveExpectTypeOf<any>
 
   type FunctionsDict = Record<Exclude<Keys, (typeof nonFunctionProperties)[number]>, any>
   const obj: FunctionsDict = {

--- a/src/index.ts
+++ b/src/index.ts
@@ -747,9 +747,7 @@ export interface NegativeExpectTypeOf<Actual> extends BaseExpectTypeOf<Actual, {
  * on the value of the `positive` property in the {@linkcode Options} type.
  */
 export type ExpectTypeOf<Actual, Options extends {positive: boolean}> = Options['positive'] extends true
-  ? IsAny<Actual> extends true
-    ? Pick<PositiveExpectTypeOf<Actual>, 'toBeAny'>
-    : PositiveExpectTypeOf<Actual>
+  ? PositiveExpectTypeOf<Actual>
   : NegativeExpectTypeOf<Actual>
 
 /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -1207,7 +1207,7 @@ export const expectTypeOf: _ExpectTypeOf = <Actual>(
     'asserts',
     'branded',
   ] as const
-  type Keys = keyof PositiveExpectTypeOf<{}>
+  type Keys = keyof PositiveExpectTypeOf<{}> | keyof NegativeExpectTypeOf<{}>
 
   type FunctionsDict = Record<Exclude<Keys, (typeof nonFunctionProperties)[number]>, any>
   const obj: FunctionsDict = {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1209,7 +1209,7 @@ export const expectTypeOf: _ExpectTypeOf = <Actual>(
     'asserts',
     'branded',
   ] as const
-  type Keys = keyof PositiveExpectTypeOf<any>
+  type Keys = keyof PositiveExpectTypeOf<{}>
 
   type FunctionsDict = Record<Exclude<Keys, (typeof nonFunctionProperties)[number]>, any>
   const obj: FunctionsDict = {

--- a/test/__snapshots__/errors.test.ts.snap
+++ b/test/__snapshots__/errors.test.ts.snap
@@ -55,8 +55,7 @@ test/usage.test.ts:999:999 - error TS2344: Type '{ deeply: { nested: unknown; };
 
 999   expectTypeOf<{deeply: {nested: any}}>().toEqualTypeOf<{deeply: {nested: unknown}}>()
                                                             ~~~~~~~~~~~~~~~~~~~~~~~~~~~
-test/usage.test.ts:999:999 - error TS2349: This expression is not callable.
-  Type 'ExpectNumber<any>' has no call signatures.
+test/usage.test.ts:999:999 - error TS2339: Property 'toBeNumber' does not exist on type 'Pick<Pick<PositiveAssertions<any>, "toBeAny">, "toBeAny">'.
 
 999   expectTypeOf(badIntParser).returns.toBeNumber()
                                          ~~~~~~~~~~
@@ -258,33 +257,12 @@ test/usage.test.ts:999:999 - error TS2554: Expected 1 arguments, but got 0.
     999       ...MISMATCH: MismatchArgs<StrictEqualUsingTSInternalIdenticalToOperator<Actual, Expected>, true>
               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     Arguments for the rest parameter 'MISMATCH' were not provided.
-test/usage.test.ts:999:999 - error TS2769: No overload matches this call.
-  Overload 1 of 2, '(value: ((IsNever<this> extends IsNever<this> ? true : false) extends true ? unknown : MismatchInfo<this, this>) & AValue, ...MISMATCH: MismatchArgs<StrictEqualUsingTSInternalIdenticalToOperator<this, (IsNever<...> extends IsNever<...> ? true : false) extends true ? unknown : MismatchInfo<...>>, true>): true', gave the following error.
-    Argument of type 'this' is not assignable to parameter of type '((IsNever<this> extends IsNever<this> ? true : false) extends true ? unknown : MismatchInfo<this, this>) & AValue'.
-      Type 'B' is not assignable to type '((IsNever<this> extends IsNever<this> ? true : false) extends true ? unknown : MismatchInfo<this, this>) & AValue'.
-        Type 'B' is not assignable to type '((IsNever<this> extends IsNever<this> ? true : false) extends true ? unknown : MismatchInfo<this, this>) & { [avalue]?: undefined; }'.
-          Type 'this' is not assignable to type '((IsNever<this> extends IsNever<this> ? true : false) extends true ? unknown : MismatchInfo<this, this>) & { [avalue]?: undefined; }'.
-            Type 'B' is not assignable to type '((IsNever<this> extends IsNever<this> ? true : false) extends true ? unknown : MismatchInfo<this, this>) & { [avalue]?: undefined; }'.
-              Type 'B' is not assignable to type '(IsNever<this> extends IsNever<this> ? true : false) extends true ? unknown : MismatchInfo<this, this>'.
-                Type 'this' is not assignable to type '(IsNever<this> extends IsNever<this> ? true : false) extends true ? unknown : MismatchInfo<this, this>'.
-                  Type 'B' is not assignable to type '(IsNever<this> extends IsNever<this> ? true : false) extends true ? unknown : MismatchInfo<this, this>'.
-  Argument of type '[this]' is not assignable to parameter of type 'MismatchArgs<StrictEqualUsingTSInternalIdenticalToOperator<this, StrictEqualUsingTSInternalIdenticalToOperator<this, unknown> extends true ? unknown : MismatchInfo<this, unknown>>, true>'.
+test/usage.test.ts:999:999 - error TS2339: Property 'toEqualTypeOf' does not exist on type 'IsAny<this> extends true ? Pick<PositiveExpectTypeOf<this>, "toBeAny"> : PositiveExpectTypeOf<this>'.
 
 999       expectTypeOf(this).toEqualTypeOf(this)
-                                           ~~~~
-
-test/usage.test.ts:999:999 - error TS2769: No overload matches this call.
-  Overload 1 of 2, '(value: (Extends<this, this> extends true ? unknown : MismatchInfo<this, this>) & AValue, ...MISMATCH: MismatchArgs<Extends<this, Extends<this, this> extends true ? unknown : MismatchInfo<...>>, true>): true', gave the following error.
-    Argument of type 'this' is not assignable to parameter of type '(Extends<this, this> extends true ? unknown : MismatchInfo<this, this>) & AValue'.
-      Type 'B' is not assignable to type '(Extends<this, this> extends true ? unknown : MismatchInfo<this, this>) & AValue'.
-        Type 'B' is not assignable to type '(Extends<this, this> extends true ? unknown : MismatchInfo<this, this>) & { [avalue]?: undefined; }'.
-          Type 'this' is not assignable to type '(Extends<this, this> extends true ? unknown : MismatchInfo<this, this>) & { [avalue]?: undefined; }'.
-            Type 'B' is not assignable to type '(Extends<this, this> extends true ? unknown : MismatchInfo<this, this>) & { [avalue]?: undefined; }'.
-              Type 'B' is not assignable to type 'Extends<this, this> extends true ? unknown : MismatchInfo<this, this>'.
-                Type 'this' is not assignable to type 'Extends<this, this> extends true ? unknown : MismatchInfo<this, this>'.
-                  Type 'B' is not assignable to type 'Extends<this, this> extends true ? unknown : MismatchInfo<this, this>'.
-  Argument of type '[this]' is not assignable to parameter of type 'MismatchArgs<Extends<this, Extends<this, unknown> extends true ? unknown : MismatchInfo<this, unknown>>, true>'.
+                             ~~~~~~~~~~~~~
+test/usage.test.ts:999:999 - error TS2339: Property 'toMatchTypeOf' does not exist on type 'IsAny<this> extends true ? Pick<PositiveExpectTypeOf<this>, "toBeAny"> : PositiveExpectTypeOf<this>'.
 
 999       expectTypeOf(this).toMatchTypeOf(this)
-                                           ~~~~"
+                             ~~~~~~~~~~~~~"
 `;

--- a/test/__snapshots__/errors.test.ts.snap
+++ b/test/__snapshots__/errors.test.ts.snap
@@ -55,7 +55,7 @@ test/usage.test.ts:999:999 - error TS2344: Type '{ deeply: { nested: unknown; };
 
 999   expectTypeOf<{deeply: {nested: any}}>().toEqualTypeOf<{deeply: {nested: unknown}}>()
                                                             ~~~~~~~~~~~~~~~~~~~~~~~~~~~
-test/usage.test.ts:999:999 - error TS2339: Property 'toBeNumber' does not exist on type 'Pick<Pick<PositiveAssertions<any>, "toBeAny">, "toBeAny">'.
+test/usage.test.ts:999:999 - error TS2339: Property 'toBeNumber' does not exist on type 'Pick<PositiveAssertions<any>, "toBeAny">'.
 
 999   expectTypeOf(badIntParser).returns.toBeNumber()
                                          ~~~~~~~~~~
@@ -257,11 +257,11 @@ test/usage.test.ts:999:999 - error TS2554: Expected 1 arguments, but got 0.
     999       ...MISMATCH: MismatchArgs<StrictEqualUsingTSInternalIdenticalToOperator<Actual, Expected>, true>
               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     Arguments for the rest parameter 'MISMATCH' were not provided.
-test/usage.test.ts:999:999 - error TS2339: Property 'toEqualTypeOf' does not exist on type 'IsAny<this> extends true ? Pick<PositiveExpectTypeOf<this>, "toBeAny"> : PositiveExpectTypeOf<this>'.
+test/usage.test.ts:999:999 - error TS2339: Property 'toEqualTypeOf' does not exist on type 'PositiveExpectTypeOf<this>'.
 
 999       expectTypeOf(this).toEqualTypeOf(this)
                              ~~~~~~~~~~~~~
-test/usage.test.ts:999:999 - error TS2339: Property 'toMatchTypeOf' does not exist on type 'IsAny<this> extends true ? Pick<PositiveExpectTypeOf<this>, "toBeAny"> : PositiveExpectTypeOf<this>'.
+test/usage.test.ts:999:999 - error TS2339: Property 'toMatchTypeOf' does not exist on type 'PositiveExpectTypeOf<this>'.
 
 999       expectTypeOf(this).toMatchTypeOf(this)
                              ~~~~~~~~~~~~~"

--- a/test/types.test.ts
+++ b/test/types.test.ts
@@ -733,3 +733,13 @@ test('Issue #53: `.omit()` should work similarly to `Omit`', () => {
 
   expectTypeOf<Loading | Failed>().omit<'code'>().toEqualTypeOf<{state: 'loading' | 'failed'}>()
 })
+
+test('Only `toBeAny` is available for `any`', () => {
+  expectTypeOf<any>().toBeAny()
+
+  // @ts-expect-error
+  expectTypeOf<any>().toMatchTypeOf<{a: 1}>()
+
+  const anyAssertions = expectTypeOf<any>()
+  expectTypeOf<keyof typeof anyAssertions>().toEqualTypeOf<'toBeAny'>()
+})


### PR DESCRIPTION
@aryaemami59 @mrazauskas

Proposal for protecting against any in a fairly simple way. This might break some people's tests, but I imagine 99% are in cases where an `any` has unexpectedly snuck in.

Related: [this comment](https://github.com/mmkal/expect-type/pull/65#issuecomment-2005771428)