### PR TITLE
Document few aspects of `.toMatchTypeOf` behaviour

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ import {expectTypeOf} from 'expect-type'
 import {foo, bar} from '../foo'
 
 // make sure `foo` has type {a: number}
-expectTypeOf(foo).toMatchTypeOf<{a: number}>()
+expectTypeOf(foo).toEqualTypeOf<{a: number}>()
 
 // make sure `bar` is a function taking a string:
 expectTypeOf(bar).parameter(0).toBeString()
@@ -101,6 +101,35 @@ expectTypeOf({a: 1}).toEqualTypeOf<{a: number; b: number}>()
 expectTypeOf({a: 1}).toMatchTypeOf<{a: number; b: number}>()
 ```
 
+`.toEqualTypeOf` distinguishes between deeply-nested `any` and `unknown` properties:
+
+```typescript
+expectTypeOf<{deeply: {nested: any}}>().not.toEqualTypeOf<{deeply: {nested: unknown}}>()
+```
+
+`.toMatchTypeOf` is meant to be a loose check and it allows `any`:
+
+```typescript
+expectTypeOf<any>().not.toEqualTypeOf<{a: number}>()
+expectTypeOf<any>().toMatchTypeOf<{a: number}>()
+
+expectTypeOf<{a: any}>().not.toEqualTypeOf<{a: number}>()
+expectTypeOf<{a: any}>().toMatchTypeOf<{a: number}>()
+
+expectTypeOf<any[]>().not.toEqualTypeOf<number[]>()
+expectTypeOf<any[]>().toMatchTypeOf<number[]>()
+```
+
+Because of the same reason, `.toMatchTypeOf` also does not take into account readonly properties:
+
+```typescript
+expectTypeOf<{ readonly a: string; b: number }>().not.toEqualTypeOf<{ a: string; b: number }>();
+
+// both checks are passing
+expectTypeOf<{ readonly a: string; b: number }>().toMatchTypeOf<{ a: string }>();
+expectTypeOf<{ readonly a: string; b: number }>().toMatchTypeOf<{ readonly a: string }>();
+```
+
 Another example of the difference between `.toMatchTypeOf` and `.toEqualTypeOf`, using generics. `.toMatchTypeOf` can be used for "is-a" relationships:
 
 ```typescript
@@ -143,12 +172,6 @@ expectTypeOf<never>().toBeNever()
 
 // @ts-expect-error
 expectTypeOf<never>().toBeNumber()
-```
-
-`.toEqualTypeOf` distinguishes between deeply-nested `any` and `unknown` properties:
-
-```typescript
-expectTypeOf<{deeply: {nested: any}}>().not.toEqualTypeOf<{deeply: {nested: unknown}}>()
 ```
 
 Test for basic javascript types:
@@ -714,4 +737,4 @@ Once you're ready to make a pull request: clone the repo, and install pnpm if yo
 
 If you're adding a feature, you should write a self-contained usage example in the form of a test, in [test/usage.test.ts](./test/usage.test.ts). This file is used to populate the bulk of this readme using [eslint-plugin-codegen](https://npmjs.com/package/eslint-plugin-codegen), and to generate an ["errors" test file](./test/errors.test.ts), which captures the error messages that are emitted for failing assertions by the typescript compiler. So, the test name should be written as a human-readable sentence explaining the usage example. Have a look at the existing tests for an idea of the style.
 
-After adding the tests, run `npm run lint -- --fix` to update the readme, and `npm test -- --updateSnapshot` to update the errors test. The generated documentation and tests should be pushed to the same branch as the source code, and submitted as a pull request. CI will test that the docs and tests are up to date if you forget to run these commands.
+After adding the tests, run `npm run lint -- --fix` to update the readme, and `npm test -- --update` to update the errors test. The generated documentation and tests should be pushed to the same branch as the source code, and submitted as a pull request. CI will test that the docs and tests are up to date if you forget to run these commands.

--- a/README.md
+++ b/README.md
@@ -123,8 +123,8 @@ expectTypeOf<any[]>().toMatchTypeOf<number[]>()
 Because of the same reason, `.toMatchTypeOf` also does not take into account readonly properties:
 
 ```typescript
-expectTypeOf<{readonly a: string}>().not.toEqualTypeOf<{a: string; }>()
-expectTypeOf<{readonly a: string; }>().toEqualTypeOf<{ readonly a: string; }>()
+expectTypeOf<{readonly a: string}>().not.toEqualTypeOf<{a: string}>()
+expectTypeOf<{readonly a: string}>().toEqualTypeOf<{readonly a: string}>()
 
 // both checks are passing
 expectTypeOf<{readonly a: string; b: number}>().toMatchTypeOf<{a: string}>()

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ expectTypeOf({a: 1}).toMatchTypeOf<{a: number; b: number}>()
 expectTypeOf<{deeply: {nested: any}}>().not.toEqualTypeOf<{deeply: {nested: unknown}}>()
 ```
 
-`.toMatchTypeOf` is meant to be a loose check and it allows `any`:
+In contrary `.toMatchTypeOf` is meant to be a loose check and it allows `any`:
 
 ```typescript
 expectTypeOf<any>().not.toEqualTypeOf<{a: number}>()
@@ -123,11 +123,12 @@ expectTypeOf<any[]>().toMatchTypeOf<number[]>()
 Because of the same reason, `.toMatchTypeOf` also does not take into account readonly properties:
 
 ```typescript
-expectTypeOf<{ readonly a: string; b: number }>().not.toEqualTypeOf<{ a: string; b: number }>();
+expectTypeOf<{readonly a: string}>().not.toEqualTypeOf<{a: string; }>()
+expectTypeOf<{readonly a: string; }>().toEqualTypeOf<{ readonly a: string; }>()
 
 // both checks are passing
-expectTypeOf<{ readonly a: string; b: number }>().toMatchTypeOf<{ a: string }>();
-expectTypeOf<{ readonly a: string; b: number }>().toMatchTypeOf<{ readonly a: string }>();
+expectTypeOf<{readonly a: string; b: number}>().toMatchTypeOf<{a: string}>()
+expectTypeOf<{readonly a: string; b: number}>().toMatchTypeOf<{readonly a: string}>()
 ```
 
 Another example of the difference between `.toMatchTypeOf` and `.toEqualTypeOf`, using generics. `.toMatchTypeOf` can be used for "is-a" relationships:

--- a/test/__snapshots__/errors.test.ts.snap
+++ b/test/__snapshots__/errors.test.ts.snap
@@ -41,8 +41,8 @@ test/usage.test.ts:999:999 - error TS2344: Type 'number[]' does not satisfy the 
                                           ~~~~~~~~
 test/usage.test.ts:999:999 - error TS2554: Expected 1 arguments, but got 0.
 
-999   expectTypeOf<{readonly a: string; b: number}>().toEqualTypeOf<{a: string; b: number}>()
-                                                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+999   expectTypeOf<{readonly a: string}>().toEqualTypeOf<{a: string}>()
+                                           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
   src/index.ts:999:999
     999       ...MISMATCH: MismatchArgs<StrictEqualUsingTSInternalIdenticalToOperator<Actual, Expected>, true>

--- a/test/__snapshots__/errors.test.ts.snap
+++ b/test/__snapshots__/errors.test.ts.snap
@@ -18,6 +18,36 @@ test/usage.test.ts:999:999 - error TS2344: Type '{ a: number; b: number; }' does
 
 999   expectTypeOf({a: 1}).toMatchTypeOf<{a: number; b: number}>()
                                          ~~~~~~~~~~~~~~~~~~~~~~
+test/usage.test.ts:999:999 - error TS2344: Type '{ deeply: { nested: unknown; }; }' does not satisfy the constraint '{ deeply: { nested: "Expected: unknown, Actual: never"; }; }'.
+  The types of 'deeply.nested' are incompatible between these types.
+    Type 'unknown' is not assignable to type '"Expected: unknown, Actual: never"'.
+
+999   expectTypeOf<{deeply: {nested: any}}>().toEqualTypeOf<{deeply: {nested: unknown}}>()
+                                                            ~~~~~~~~~~~~~~~~~~~~~~~~~~~
+test/usage.test.ts:999:999 - error TS2344: Type '{ a: number; }' does not satisfy the constraint 'never'.
+
+999   expectTypeOf<any>().toEqualTypeOf<{a: number}>()
+                                        ~~~~~~~~~~~
+test/usage.test.ts:999:999 - error TS2344: Type '{ a: number; }' does not satisfy the constraint '{ a: never; }'.
+  Types of property 'a' are incompatible.
+    Type 'number' is not assignable to type 'never'.
+
+999   expectTypeOf<{a: any}>().toEqualTypeOf<{a: number}>()
+                                             ~~~~~~~~~~~
+test/usage.test.ts:999:999 - error TS2344: Type 'number[]' does not satisfy the constraint 'never[]'.
+  Type 'number' is not assignable to type 'never'.
+
+999   expectTypeOf<any[]>().toEqualTypeOf<number[]>()
+                                          ~~~~~~~~
+test/usage.test.ts:999:999 - error TS2554: Expected 1 arguments, but got 0.
+
+999   expectTypeOf<{readonly a: string; b: number}>().toEqualTypeOf<{a: string; b: number}>()
+                                                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+  src/index.ts:999:999
+    999       ...MISMATCH: MismatchArgs<StrictEqualUsingTSInternalIdenticalToOperator<Actual, Expected>, true>
+              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    Arguments for the rest parameter 'MISMATCH' were not provided.
 test/usage.test.ts:999:999 - error TS2344: Type 'Apple' does not satisfy the constraint '{ name: "Expected: literal string: Apple, Actual: never"; type: "Fruit"; edible: "Expected: literal boolean: true, Actual: literal boolean: false"; }'.
   Types of property 'name' are incompatible.
     Type '"Apple"' is not assignable to type '"Expected: literal string: Apple, Actual: never"'.
@@ -49,12 +79,6 @@ test/usage.test.ts:999:999 - error TS2349: This expression is not callable.
 
 999   expectTypeOf<never>().toBeNumber()
                             ~~~~~~~~~~
-test/usage.test.ts:999:999 - error TS2344: Type '{ deeply: { nested: unknown; }; }' does not satisfy the constraint '{ deeply: { nested: "Expected: unknown, Actual: never"; }; }'.
-  The types of 'deeply.nested' are incompatible between these types.
-    Type 'unknown' is not assignable to type '"Expected: unknown, Actual: never"'.
-
-999   expectTypeOf<{deeply: {nested: any}}>().toEqualTypeOf<{deeply: {nested: unknown}}>()
-                                                            ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 test/usage.test.ts:999:999 - error TS2349: This expression is not callable.
   Type 'ExpectNumber<any>' has no call signatures.
 
@@ -149,7 +173,6 @@ test/usage.test.ts:999:999 - error TS2349: This expression is not callable.
 999   expectTypeOf([1, 2, 3]).items.toBeString()
                                     ~~~~~~~~~~
 test/usage.test.ts:999:999 - error TS2344: Type 'number[]' does not satisfy the constraint 'never[]'.
-  Type 'number' is not assignable to type 'never'.
 
 999   expectTypeOf<any[]>().toEqualTypeOf<number[]>()
                                           ~~~~~~~~

--- a/test/usage.test.ts
+++ b/test/usage.test.ts
@@ -33,6 +33,29 @@ test('`.toEqualTypeOf` and `.toMatchTypeOf` both fail on missing properties', ()
   expectTypeOf({a: 1}).toMatchTypeOf<{a: number; b: number}>()
 })
 
+test('`.toEqualTypeOf` distinguishes between deeply-nested `any` and `unknown` properties', () => {
+  expectTypeOf<{deeply: {nested: any}}>().not.toEqualTypeOf<{deeply: {nested: unknown}}>()
+})
+
+test('In contrary `.toMatchTypeOf` is meant to be a loose check and it allows `any`', () => {
+  expectTypeOf<any>().not.toEqualTypeOf<{a: number}>()
+  expectTypeOf<any>().toMatchTypeOf<{a: number}>()
+
+  expectTypeOf<{a: any}>().not.toEqualTypeOf<{a: number}>()
+  expectTypeOf<{a: any}>().toMatchTypeOf<{a: number}>()
+
+  expectTypeOf<any[]>().not.toEqualTypeOf<number[]>()
+  expectTypeOf<any[]>().toMatchTypeOf<number[]>()
+})
+
+test('Because of the same reason, `.toMatchTypeOf` also does not take into account readonly properties', () => {
+  expectTypeOf<{readonly a: string; b: number}>().not.toEqualTypeOf<{a: string; b: number}>()
+
+  // both checks are passing
+  expectTypeOf<{readonly a: string; b: number}>().toMatchTypeOf<{a: string}>()
+  expectTypeOf<{readonly a: string; b: number}>().toMatchTypeOf<{readonly a: string}>()
+})
+
 test('Another example of the difference between `.toMatchTypeOf` and `.toEqualTypeOf`, using generics. `.toMatchTypeOf` can be used for "is-a" relationships', () => {
   type Fruit = {type: 'Fruit'; edible: boolean}
   type Apple = {type: 'Fruit'; name: 'Apple'; edible: true}
@@ -67,10 +90,6 @@ test('Catch any/unknown/never types', () => {
 
   // @ts-expect-error
   expectTypeOf<never>().toBeNumber()
-})
-
-test('`.toEqualTypeOf` distinguishes between deeply-nested `any` and `unknown` properties', () => {
-  expectTypeOf<{deeply: {nested: any}}>().not.toEqualTypeOf<{deeply: {nested: unknown}}>()
 })
 
 // eslint-disable-next-line vitest/valid-title

--- a/test/usage.test.ts
+++ b/test/usage.test.ts
@@ -49,7 +49,8 @@ test('In contrary `.toMatchTypeOf` is meant to be a loose check and it allows `a
 })
 
 test('Because of the same reason, `.toMatchTypeOf` also does not take into account readonly properties', () => {
-  expectTypeOf<{readonly a: string; b: number}>().not.toEqualTypeOf<{a: string; b: number}>()
+  expectTypeOf<{readonly a: string}>().not.toEqualTypeOf<{a: string}>()
+  expectTypeOf<{readonly a: string}>().toEqualTypeOf<{readonly a: string}>()
 
   // both checks are passing
   expectTypeOf<{readonly a: string; b: number}>().toMatchTypeOf<{a: string}>()


### PR DESCRIPTION
From https://github.com/mmkal/expect-type/issues/55#issuecomment-2013750056

Closes #55
Closes #66 (perhaps?)

@mmkal Thanks for explanations. Here is an attempt to summarise of how I understood the intended behaviour of`.toMatchTypeOf`. Feel free to rework or to clarify further.