### PR TITLE
Fix rendering issue in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,8 +61,6 @@ The `expectTypeOf` method takes a single argument, or a generic parameter. Neith
 <!-- codegen:start {preset: markdownFromTests, source: test/usage.test.ts} -->
 Check an object's type with `.toEqualTypeOf`:
 
-eslint prettier/prettier: ["warn", { "singleQuote": true, "semi": false, "arrowParens": "avoid", "trailingComma": "es5", "bracketSpacing": false, "endOfLine": "auto", "printWidth": 100 }]
-
 ```typescript
 expectTypeOf({a: 1}).toEqualTypeOf<{a: number}>()
 ```

--- a/test/usage.test.ts
+++ b/test/usage.test.ts
@@ -1,9 +1,9 @@
 /* eslint-disable @typescript-eslint/no-empty-function */
 /* eslint-disable @typescript-eslint/ban-ts-comment */
+/* eslint prettier/prettier: ["warn", { "singleQuote": true, "semi": false, "arrowParens": "avoid", "trailingComma": "es5", "bracketSpacing": false, "endOfLine": "auto", "printWidth": 100 }] */
+
 import {test} from 'vitest'
 import {expectTypeOf} from '../src'
-
-/* eslint prettier/prettier: ["warn", { "singleQuote": true, "semi": false, "arrowParens": "avoid", "trailingComma": "es5", "bracketSpacing": false, "endOfLine": "auto", "printWidth": 100 }] */
 
 test("Check an object's type with `.toEqualTypeOf`", () => {
   expectTypeOf({a: 1}).toEqualTypeOf<{a: number}>()


### PR DESCRIPTION
Currently an `eslint` comment is seeking into readme. Seems like it should not be there.