### PR TITLE
Add `property` method to extract object properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,6 +271,43 @@ type Person = {name: string; age: number}
 expectTypeOf<Person>().pick<'name'>().toEqualTypeOf<{name: string}>()
 ```
 
+Use `.property` to pick a property from an object and narrow down complex objects:
+
+```typescript
+type CSSDisplay = 'flex' | 'grid' | 'block';
+interface CSSProperties {
+  display: CSSDisplay | `inline-${CSSDisplay}`;
+  font?: {
+    size?: 'lg' | 'sm' | 'xl' | 'base';
+    style?: 'normal' | 'italic' | 'bold';
+  };
+}
+
+const cssProperties: CSSProperties = { display: 'block' };
+
+class CSSPropertyBuilder {
+  public constructor() { }
+
+  public css!: CSSProperties;
+  public build(css: CSSProperties): CSSProperties {
+    this.css = css;
+    return css;
+  }
+}
+
+// instance object
+expectTypeOf(CSSPropertyBuilder).instance.toHaveProperty('build');
+expectTypeOf(CSSPropertyBuilder).instance.property('build').toBeFunction();
+expectTypeOf(CSSPropertyBuilder).instance.pick('build').not.toBeFunction();
+
+// plain object
+expectTypeOf(cssProperties).property('display').toBeString();
+expectTypeOf<CSSProperties>().property('display').toEqualTypeOf<CSSDisplay | `inline-${CSSDisplay}`>();
+
+// deep-nested instance
+expectTypeOf(CSSPropertyBuilder).instance.property('css').property('display').not.toBeNullable();
+```
+
 Use `.omit` to remove a set of properties from an object:
 
 ```typescript

--- a/src/index.ts
+++ b/src/index.ts
@@ -189,6 +189,11 @@ export interface PositiveExpectTypeOf<Actual> extends BaseExpectTypeOf<Actual, {
     ...MISMATCH: MismatchArgs<Extends<KeyType, keyof Actual>, true>
   ) => KeyType extends keyof Actual ? PositiveExpectTypeOf<Actual[KeyType]> : true
 
+  property: <KeyType extends keyof Required<Actual>>(
+    key: KeyType,
+    ...MISMATCH: MismatchArgs<Extends<KeyType, keyof Actual>, true>
+  ) => PositiveExpectTypeOf<Actual[KeyType]>
+
   /**
    * Inverts the result of the following assertions.
    *
@@ -899,6 +904,7 @@ export const expectTypeOf: _ExpectTypeOf = <Actual>(
     toBeCallableWith: fn,
     toBeConstructibleWith: fn,
     /* eslint-enable @typescript-eslint/no-unsafe-assignment */
+    property: expectTypeOf,
     extract: expectTypeOf,
     exclude: expectTypeOf,
     pick: expectTypeOf,

--- a/src/index.ts
+++ b/src/index.ts
@@ -189,6 +189,26 @@ export interface PositiveExpectTypeOf<Actual> extends BaseExpectTypeOf<Actual, {
     ...MISMATCH: MismatchArgs<Extends<KeyType, keyof Actual>, true>
   ) => KeyType extends keyof Actual ? PositiveExpectTypeOf<Actual[KeyType]> : true
 
+  /**
+   * Extracts a certain object properties with `.property(key)` call to
+   * perform other assertions on it.
+   *
+   * @example
+   * ```ts
+   * const foo = {
+   *   bar: 10,
+   *   baz: 'hello world',
+   * }
+   *
+   * expectTypeOf(foo).property('bar').toBeNumber()
+   *
+   * expectTypeOf(foo).parameter('baz').toBeString()
+   * ```
+   *
+   * @param key - The property key of the properties to extract.
+   * @returns The extracted property type.
+   */
+
   property: <KeyType extends keyof Required<Actual>>(
     key: KeyType,
     ...MISMATCH: MismatchArgs<Extends<KeyType, keyof Actual>, true>

--- a/test/usage.test.ts
+++ b/test/usage.test.ts
@@ -175,6 +175,43 @@ test('Use `.pick` to pick a set of properties from an object', () => {
   expectTypeOf<Person>().pick<'name'>().toEqualTypeOf<{name: string}>()
 })
 
+test('Use `.property` to pick a property from an object and narrow down complex objects', () => {
+  type CSSDisplay = 'flex' | 'grid' | 'block'
+  interface CSSProperties {
+    display: CSSDisplay | `inline-${CSSDisplay}`
+    font?: {
+      size?: 'lg' | 'sm' | 'xl' | 'base'
+      style?: 'normal' | 'italic' | 'bold'
+    }
+  }
+
+  const cssProperties: CSSProperties = {display: 'block'}
+
+  class CSSPropertyBuilder {
+    public constructor() {}
+
+    public css!: CSSProperties
+    public build(css: CSSProperties): CSSProperties {
+      this.css = css
+      return css
+    }
+  }
+
+  // instance object
+  expectTypeOf(CSSPropertyBuilder).instance.toHaveProperty('build')
+  expectTypeOf(CSSPropertyBuilder).instance.property('build').toBeFunction()
+  expectTypeOf(CSSPropertyBuilder).instance.pick('build').not.toBeFunction()
+
+  // plain object
+  expectTypeOf(cssProperties).property('display').toBeString()
+  expectTypeOf<CSSProperties>()
+    .property('display')
+    .toEqualTypeOf<CSSDisplay | `inline-${CSSDisplay}`>()
+
+  // deep-nested instance
+  expectTypeOf(CSSPropertyBuilder).instance.property('css').property('display').not.toBeNullable()
+})
+
 test('Use `.omit` to remove a set of properties from an object', () => {
   type Person = {name: string; age: number}
 


### PR DESCRIPTION
Hello @mmkal! 👋

Thank you for your hard work on the `expect-type` library! I really appreciate the effort you put into maintaining such a valuable tool for the community.

As I’ve been using the library, I noticed that it could be even more powerful with the addition of a new method. This pull request proposes the addition of a `property` method that allows users to extract specific properties from an object and perform type assertions on them. 

The `property` method will enable users to easily check the types of individual properties within an object, enhancing the library's functionality and improving its usability.

For example:

```typescript
const user = {
  name: 'Alice',
  age: 30,
};

expectTypeOf(user).property('name').toBeString();
expectTypeOf(user).property('age').toBeNumber();
```

Let me know if you have any questions or need further changes!