### PR TITLE
Mark internal APIs with `@internal` JSDoc tag

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -28,6 +28,7 @@ import {StrictEqualUsingTSInternalIdenticalToOperator, AValue, MismatchArgs, Ext
 export * from './branding' // backcompat, consider removing in next major version
 export * from './utils' // backcompat, consider removing in next major version
 export * from './messages' // backcompat, consider removing in next major version
+export * from './overloads'
 
 /**
  * Represents the positive assertion methods available for type checking in the

--- a/src/index.ts
+++ b/src/index.ts
@@ -44,8 +44,8 @@ export interface PositiveExpectTypeOf<Actual> extends BaseExpectTypeOf<Actual, {
      *
      * **_Unexpected failure_**? For a more permissive but less performant
      * check that accommodates for equivalent intersection types,
-     * use {@linkcode branded `.branded.toEqualTypeOf()`}.
-     * @see {@link https://github.com/mmkal/expect-type#why-is-my-assertion-failing The documentation for details}.
+     * use {@linkcode branded | .branded.toEqualTypeOf()}.
+     * @see {@link https://github.com/mmkal/expect-type#why-is-my-assertion-failing | The documentation for details}.
      *
      * @example
      * <caption>Using generic type argument syntax</caption>
@@ -85,8 +85,8 @@ export interface PositiveExpectTypeOf<Actual> extends BaseExpectTypeOf<Actual, {
      *
      * **_Unexpected failure_**? For a more permissive but less performant
      * check that accommodates for equivalent intersection types,
-     * use {@linkcode branded `.branded.toEqualTypeOf()`}.
-     * @see {@link https://github.com/mmkal/expect-type#why-is-my-assertion-failing The documentation for details}.
+     * use {@linkcode branded | .branded.toEqualTypeOf()}.
+     * @see {@link https://github.com/mmkal/expect-type#why-is-my-assertion-failing | The documentation for details}.
      *
      * @example
      * <caption>Using generic type argument syntax</caption>
@@ -118,7 +118,7 @@ export interface PositiveExpectTypeOf<Actual> extends BaseExpectTypeOf<Actual, {
 
   toMatchTypeOf: {
     /**
-     * A less strict version of {@linkcode toEqualTypeOf `.toEqualTypeOf()`}
+     * A less strict version of {@linkcode toEqualTypeOf | .toEqualTypeOf()}
      * that allows for extra properties.
      * This is roughly equivalent to an `extends` constraint
      * in a function type argument.
@@ -145,7 +145,7 @@ export interface PositiveExpectTypeOf<Actual> extends BaseExpectTypeOf<Actual, {
     ): true
 
     /**
-     * A less strict version of {@linkcode toEqualTypeOf `.toEqualTypeOf()`}
+     * A less strict version of {@linkcode toEqualTypeOf | .toEqualTypeOf()}
      * that allows for extra properties.
      * This is roughly equivalent to an `extends` constraint
      * in a function type argument.
@@ -204,7 +204,7 @@ export interface PositiveExpectTypeOf<Actual> extends BaseExpectTypeOf<Actual, {
 
   /**
    * Intersection types can cause issues with
-   * {@linkcode toEqualTypeOf `.toEqualTypeOf()`}:
+   * {@linkcode toEqualTypeOf | .toEqualTypeOf()}:
    * ```ts
    * // ❌ The following line doesn't compile, even though the types are arguably the same.
    * expectTypeOf<{ a: 1 } & { b: 2 }>().toEqualTypeOf<{ a: 1; b: 2 }>()
@@ -215,7 +215,7 @@ export interface PositiveExpectTypeOf<Actual> extends BaseExpectTypeOf<Actual, {
    * __Note__: This comes at a performance cost, and can cause the compiler
    * to 'give up' if used with excessively deep types, so use sparingly.
    *
-   * @see {@link https://github.com/mmkal/expect-type/pull/21 Reference}
+   * @see {@link https://github.com/mmkal/expect-type/pull/21 | Reference}
    */
   branded: {
     /**
@@ -227,8 +227,8 @@ export interface PositiveExpectTypeOf<Actual> extends BaseExpectTypeOf<Actual, {
      *
      * **_Unexpected failure_**? For a more permissive but less performant
      * check that accommodates for equivalent intersection types,
-     * use {@linkcode PositiveExpectTypeOf.branded `.branded.toEqualTypeOf()`}.
-     * @see {@link https://github.com/mmkal/expect-type#why-is-my-assertion-failing The documentation for details}.
+     * use {@linkcode PositiveExpectTypeOf.branded | .branded.toEqualTypeOf()}.
+     * @see {@link https://github.com/mmkal/expect-type#why-is-my-assertion-failing | The documentation for details}.
      *
      * @example
      * <caption>Using generic type argument syntax</caption>
@@ -273,8 +273,8 @@ export interface NegativeExpectTypeOf<Actual> extends BaseExpectTypeOf<Actual, {
      *
      * **_Unexpected failure_**? For a more permissive but less performant
      * check that accommodates for equivalent intersection types,
-     * use {@linkcode PositiveExpectTypeOf.branded `.branded.toEqualTypeOf()`}.
-     * @see {@link https://github.com/mmkal/expect-type#why-is-my-assertion-failing The documentation for details}.
+     * use {@linkcode PositiveExpectTypeOf.branded | .branded.toEqualTypeOf()}.
+     * @see {@link https://github.com/mmkal/expect-type#why-is-my-assertion-failing | The documentation for details}.
      *
      * @example
      * <caption>Using generic type argument syntax</caption>
@@ -310,8 +310,8 @@ export interface NegativeExpectTypeOf<Actual> extends BaseExpectTypeOf<Actual, {
      *
      * **_Unexpected failure_**? For a more permissive but less performant
      * check that accommodates for equivalent intersection types,
-     * use {@linkcode PositiveExpectTypeOf.branded `.branded.toEqualTypeOf()`}.
-     * @see {@link https://github.com/mmkal/expect-type#why-is-my-assertion-failing The documentation for details}.
+     * use {@linkcode PositiveExpectTypeOf.branded | .branded.toEqualTypeOf()}.
+     * @see {@link https://github.com/mmkal/expect-type#why-is-my-assertion-failing | The documentation for details}.
      *
      * @example
      * <caption>Using generic type argument syntax</caption>
@@ -338,7 +338,7 @@ export interface NegativeExpectTypeOf<Actual> extends BaseExpectTypeOf<Actual, {
   toMatchTypeOf: {
     /**
      * A less strict version of
-     * {@linkcode PositiveExpectTypeOf.toEqualTypeOf `.toEqualTypeOf()`}
+     * {@linkcode PositiveExpectTypeOf.toEqualTypeOf | .toEqualTypeOf()}
      * that allows for extra properties.
      * This is roughly equivalent to an `extends` constraint
      * in a function type argument.
@@ -366,7 +366,7 @@ export interface NegativeExpectTypeOf<Actual> extends BaseExpectTypeOf<Actual, {
 
     /**
      * A less strict version of
-     * {@linkcode PositiveExpectTypeOf.toEqualTypeOf `.toEqualTypeOf()`}
+     * {@linkcode PositiveExpectTypeOf.toEqualTypeOf | .toEqualTypeOf()}
      * that allows for extra properties.
      * This is roughly equivalent to an `extends` constraint
      * in a function type argument.
@@ -501,7 +501,7 @@ export interface BaseExpectTypeOf<Actual, Options extends {positive: boolean}> {
    * Checks whether a function is callable with the given parameters.
    *
    * __Note__: You cannot negate this assertion with
-   * {@linkcode PositiveExpectTypeOf.not `.not`}, you need to use
+   * {@linkcode PositiveExpectTypeOf.not | .not}, you need to use
    * `ts-expect-error` instead.
    *
    * @example
@@ -513,7 +513,7 @@ export interface BaseExpectTypeOf<Actual, Options extends {positive: boolean}> {
    *
    * __Known Limitation__: This assertion will likely fail if you try to use it
    * with a generic function or an overload.
-   * @see {@link https://github.com/mmkal/expect-type/issues/50 This issue} for an example and a workaround.
+   * @see {@link https://github.com/mmkal/expect-type/issues/50 | This issue} for an example and a workaround.
    *
    * @param args - The arguments to check for callability.
    * @returns `true`.

--- a/src/index.ts
+++ b/src/index.ts
@@ -854,6 +854,7 @@ export type _ExpectTypeOf = {
  * form of a reference or generic type parameter.
  *
  * @example
+ * ```ts
  * import { foo, bar } from '../foo'
  * import { expectTypeOf } from 'expect-type'
  *
@@ -866,6 +867,7 @@ export type _ExpectTypeOf = {
  *   expectTypeOf(bar).parameter(0).toBeString()
  *   expectTypeOf(bar).returns.not.toBeAny()
  * })
+ * ```
  *
  * @description
  * See the [full docs](https://npmjs.com/package/expect-type#documentation) for lots more examples.

--- a/src/messages.ts
+++ b/src/messages.ts
@@ -51,48 +51,97 @@ export type MismatchInfo<Actual, Expected> =
       ? Actual
       : `Expected: ${PrintType<Expected>}, Actual: ${PrintType<Exclude<Actual, Expected>>}`
 
+/**
+ * @internal
+ */
 const inverted = Symbol('inverted')
+
+/**
+ * @internal
+ */
 type Inverted<T> = {[inverted]: T}
 
+/**
+ * @internal
+ */
 const expectNull = Symbol('expectNull')
 export type ExpectNull<T> = {[expectNull]: T; result: ExtendsExcludingAnyOrNever<T, null>}
 
+/**
+ * @internal
+ */
 const expectUndefined = Symbol('expectUndefined')
 export type ExpectUndefined<T> = {[expectUndefined]: T; result: ExtendsExcludingAnyOrNever<T, undefined>}
 
+/**
+ * @internal
+ */
 const expectNumber = Symbol('expectNumber')
 export type ExpectNumber<T> = {[expectNumber]: T; result: ExtendsExcludingAnyOrNever<T, number>}
 
+/**
+ * @internal
+ */
 const expectString = Symbol('expectString')
 export type ExpectString<T> = {[expectString]: T; result: ExtendsExcludingAnyOrNever<T, string>}
 
+/**
+ * @internal
+ */
 const expectBoolean = Symbol('expectBoolean')
 export type ExpectBoolean<T> = {[expectBoolean]: T; result: ExtendsExcludingAnyOrNever<T, boolean>}
 
+/**
+ * @internal
+ */
 const expectVoid = Symbol('expectVoid')
 export type ExpectVoid<T> = {[expectVoid]: T; result: ExtendsExcludingAnyOrNever<T, void>}
 
+/**
+ * @internal
+ */
 const expectFunction = Symbol('expectFunction')
 export type ExpectFunction<T> = {[expectFunction]: T; result: ExtendsExcludingAnyOrNever<T, (...args: any[]) => any>}
 
+/**
+ * @internal
+ */
 const expectObject = Symbol('expectObject')
 export type ExpectObject<T> = {[expectObject]: T; result: ExtendsExcludingAnyOrNever<T, object>}
 
+/**
+ * @internal
+ */
 const expectArray = Symbol('expectArray')
 export type ExpectArray<T> = {[expectArray]: T; result: ExtendsExcludingAnyOrNever<T, any[]>}
 
+/**
+ * @internal
+ */
 const expectSymbol = Symbol('expectSymbol')
 export type ExpectSymbol<T> = {[expectSymbol]: T; result: ExtendsExcludingAnyOrNever<T, symbol>}
 
+/**
+ * @internal
+ */
 const expectAny = Symbol('expectAny')
 export type ExpectAny<T> = {[expectAny]: T; result: IsAny<T>}
 
+/**
+ * @internal
+ */
 const expectUnknown = Symbol('expectUnknown')
 export type ExpectUnknown<T> = {[expectUnknown]: T; result: IsUnknown<T>}
 
+/**
+ * @internal
+ */
 const expectNever = Symbol('expectNever')
 export type ExpectNever<T> = {[expectNever]: T; result: IsNever<T>}
 
+/**
+ * @internal
+ */
 const expectNullable = Symbol('expectNullable')
 export type ExpectNullable<T> = {[expectNullable]: T; result: Not<StrictEqualUsingBranding<T, NonNullable<T>>>}
 

--- a/src/overloads.ts
+++ b/src/overloads.ts
@@ -109,7 +109,7 @@ export type DecreasingOverloadsInfoUnion<F> = F extends {(...args: infer A1): in
 /**
  * Get a union of overload variants for a function {@linkcode FunctionType}.
  * Does a check for whether we can do the one-shot
- * 10-overload matcher (which works for ts>5.3), and if not,
+ * 10-overload matcher (which works for ts\>5.3), and if not,
  * falls back to the more complicated utility.
  *
  * @internal
@@ -259,7 +259,7 @@ export type DecreasingConstructorOverloadsInfoUnion<ConstructorType> = Construct
 /**
  * Get a union of overload variants for a constructor
  * {@linkcode ConstructorType}. Does a check for whether we can do the
- * one-shot 10-overload matcher (which works for ts>5.3), and if not,
+ * one-shot 10-overload matcher (which works for ts\>5.3), and if not,
  * falls back to the more complicated utility.
  *
  * @internal

--- a/src/overloads.ts
+++ b/src/overloads.ts
@@ -32,6 +32,7 @@ export type UnknownFunction = (...args: unknown[]) => unknown
  * This is useful because older versions of TypeScript end up with
  * 9 "useless" overloads and one real one for parameterless/generic functions.
  *
+ * @see {@link https://github.com/microsoft/TypeScript/issues/28867 | Related}
  *
  * @internal
  */
@@ -60,6 +61,7 @@ export type Tuplify<Union> = Union extends infer X ? [X] : never
  * for parameterless functions. To do this we use
  * {@linkcode IsUselessOverloadInfo} to remove useless overloads.
  *
+ * @see {@link https://github.com/microsoft/TypeScript/issues/28867 | Related}
  *
  * @internal
  */
@@ -209,6 +211,7 @@ export type IsUselessConstructorOverloadInfo<FunctionType> = StrictEqualUsingTSI
  * for parameterless constructors. To do this we use
  * {@linkcode IsUselessConstructorOverloadInfo} to remove useless overloads.
  *
+ * @see {@link https://github.com/microsoft/TypeScript/issues/28867 | Related}
  *
  * @internal
  */

--- a/src/overloads.ts
+++ b/src/overloads.ts
@@ -10,6 +10,8 @@ import {StrictEqualUsingTSInternalIdenticalToOperator, IsNever, UnionToIntersect
  *
  * For older versions of TypeScript, we'll need to painstakingly do
  * ten separate matches.
+ *
+ * @internal
  */
 export type TSPost53OverloadsInfoUnion<FunctionType> =
   FunctionType extends {(...args: infer A1): infer R1; (...args: infer A2): infer R2; (...args: infer A3): infer R3; (...args: infer A4): infer R4; (...args: infer A5): infer R5; (...args: infer A6): infer R6; (...args: infer A7): infer R7; (...args: infer A8): infer R8; (...args: infer A9): infer R9; (...args: infer A10): infer R10}
@@ -18,6 +20,8 @@ export type TSPost53OverloadsInfoUnion<FunctionType> =
 
 /**
  * A function with `unknown` parameters and return type.
+ *
+ * @internal
  */
 export type UnknownFunction = (...args: unknown[]) => unknown
 
@@ -28,7 +32,8 @@ export type UnknownFunction = (...args: unknown[]) => unknown
  * This is useful because older versions of TypeScript end up with
  * 9 "useless" overloads and one real one for parameterless/generic functions.
  *
- * @see {@link https://github.com/microsoft/TypeScript/issues/28867 Related}
+ *
+ * @internal
  */
 export type IsUselessOverloadInfo<FunctionType> = StrictEqualUsingTSInternalIdenticalToOperator<
   FunctionType,
@@ -41,6 +46,8 @@ export type IsUselessOverloadInfo<FunctionType> = StrictEqualUsingTSInternalIden
  * extra `infer X` expression. There may be a better way to work around this
  * problem, but since it's not a problem in newer versions of TypeScript,
  * it's not a priority right now.
+ *
+ * @internal
  */
 export type Tuplify<Union> = Union extends infer X ? [X] : never
 
@@ -53,7 +60,8 @@ export type Tuplify<Union> = Union extends infer X ? [X] : never
  * for parameterless functions. To do this we use
  * {@linkcode IsUselessOverloadInfo} to remove useless overloads.
  *
- * @see {@link https://github.com/microsoft/TypeScript/issues/28867 Related}
+ *
+ * @internal
  */
 export type TSPre53OverloadsInfoUnion<FunctionType> =
   // first, pointlessly wrap the overload variants in a 1-tuple, then infer them as `Tup` - this helps TypeScript isolate out the overload variants
@@ -72,6 +80,8 @@ export type TSPre53OverloadsInfoUnion<FunctionType> =
 /**
  * For versions of TypeScript below 5.3, we need to check for 10 overloads,
  * then 9, then 8, etc., to get a union of the overload variants.
+ *
+ * @internal
  */
 export type DecreasingOverloadsInfoUnion<F> = F extends {(...args: infer A1): infer R1; (...args: infer A2): infer R2; (...args: infer A3): infer R3; (...args: infer A4): infer R4; (...args: infer A5): infer R5; (...args: infer A6): infer R6; (...args: infer A7): infer R7; (...args: infer A8): infer R8; (...args: infer A9): infer R9; (...args: infer A10): infer R10}
   ? ((...p: A1) => R1) | ((...p: A2) => R2) | ((...p: A3) => R3) | ((...p: A4) => R4) | ((...p: A5) => R5) | ((...p: A6) => R6) | ((...p: A7) => R7) | ((...p: A8) => R8) | ((...p: A9) => R9) | ((...p: A10) => R10)
@@ -99,6 +109,8 @@ export type DecreasingOverloadsInfoUnion<F> = F extends {(...args: infer A1): in
  * Does a check for whether we can do the one-shot
  * 10-overload matcher (which works for ts>5.3), and if not,
  * falls back to the more complicated utility.
+ *
+ * @internal
  */
 export type OverloadsInfoUnion<FunctionType> =
   // recent TypeScript versions (5.3+) can treat a 1-overload type function as a 10-overload. Test for this by seeing if we can successfully get a union from a 1-overload function. If we can't, we're on an old TypeScript and need to use the more complicated utility.
@@ -108,12 +120,16 @@ export type OverloadsInfoUnion<FunctionType> =
 
 /**
  * Allows inferring any function using the `infer` keyword.
+ *
+ * @internal
  */
 export type InferFunctionType<FunctionType extends (...args: any) => any> = FunctionType
 
 /**
  * A union type of the parameters allowed for any
  * overload of function {@linkcode FunctionType}.
+ *
+ * @internal
  */
 export type OverloadParameters<FunctionType> =
   OverloadsInfoUnion<FunctionType> extends InferFunctionType<infer Fn> ? Parameters<Fn> : never
@@ -121,6 +137,8 @@ export type OverloadParameters<FunctionType> =
 /**
  * A union type of the return types for any overload of
  * function {@linkcode FunctionType}.
+ *
+ * @internal
  */
 export type OverloadReturnTypes<FunctionType> =
   OverloadsInfoUnion<FunctionType> extends InferFunctionType<infer Fn> ? ReturnType<Fn> : never
@@ -129,6 +147,8 @@ export type OverloadReturnTypes<FunctionType> =
  * Takes an overload variants {@linkcode Union},
  * produced from {@linkcode OverloadsInfoUnion} and rejects
  * the ones incompatible with parameters {@linkcode Args}.
+ *
+ * @internal
  */
 export type SelectOverloadsInfo<Union extends UnknownFunction, Args extends unknown[]> =
   Union extends InferFunctionType<infer Fn> ? (Args extends Parameters<Fn> ? Fn : never) : never
@@ -137,6 +157,8 @@ export type SelectOverloadsInfo<Union extends UnknownFunction, Args extends unkn
  * Creates a new overload (an intersection type) from an existing one,
  * which only includes variant(s) which can accept
  * {@linkcode Args} as parameters.
+ *
+ * @internal
  */
 export type OverloadsNarrowedByParameters<
   FunctionType,
@@ -155,6 +177,8 @@ export type OverloadsNarrowedByParameters<
  *
  * For older versions of TypeScript,
  * we'll need to painstakingly do ten separate matches.
+ *
+ * @internal
  */
 export type TSPost53ConstructorOverloadsInfoUnion<ConstructorType> =
   ConstructorType extends {new (...args: infer A1): infer R1; new (...args: infer A2): infer R2; new (...args: infer A3): infer R3; new (...args: infer A4): infer R4; new (...args: infer A5): infer R5; new (...args: infer A6): infer R6; new (...args: infer A7): infer R7; new (...args: infer A8): infer R8; new (...args: infer A9): infer R9; new (...args: infer A10): infer R10}
@@ -163,12 +187,16 @@ export type TSPost53ConstructorOverloadsInfoUnion<ConstructorType> =
 
 /**
  * A constructor function with `unknown` parameters and return type.
+ *
+ * @internal
  */
 export type UnknownConstructor = new (...args: unknown[]) => unknown
 
 // prettier-ignore
 /**
  * Same as {@linkcode IsUselessOverloadInfo}, but for constructors.
+ *
+ * @internal
  */
 export type IsUselessConstructorOverloadInfo<FunctionType> = StrictEqualUsingTSInternalIdenticalToOperator<FunctionType, UnknownConstructor>
 
@@ -181,7 +209,8 @@ export type IsUselessConstructorOverloadInfo<FunctionType> = StrictEqualUsingTSI
  * for parameterless constructors. To do this we use
  * {@linkcode IsUselessConstructorOverloadInfo} to remove useless overloads.
  *
- * @see {@link https://github.com/microsoft/TypeScript/issues/28867 Related}
+ *
+ * @internal
  */
 export type TSPre53ConstructorOverloadsInfoUnion<ConstructorType> =
   // first, pointlessly wrap the overload variants in a 1-tuple, then infer them as `Tup` - this helps TypeScript isolate out the overload variants
@@ -200,6 +229,8 @@ export type TSPre53ConstructorOverloadsInfoUnion<ConstructorType> =
 /**
  * For versions of TypeScript below 5.3, we need to check for 10 overloads,
  * then 9, then 8, etc., to get a union of the overload variants.
+ *
+ * @internal
  */
 export type DecreasingConstructorOverloadsInfoUnion<ConstructorType> = ConstructorType extends {new (...args: infer A1): infer R1; new (...args: infer A2): infer R2; new (...args: infer A3): infer R3; new (...args: infer A4): infer R4; new (...args: infer A5): infer R5; new (...args: infer A6): infer R6; new (...args: infer A7): infer R7; new (...args: infer A8): infer R8; new (...args: infer A9): infer R9; new (...args: infer A10): infer R10}
   ? (new (...p: A1) => R1) | (new (...p: A2) => R2) | (new (...p: A3) => R3) | (new (...p: A4) => R4) | (new (...p: A5) => R5) | (new (...p: A6) => R6) | (new (...p: A7) => R7) | (new (...p: A8) => R8) | (new (...p: A9) => R9) | (new (...p: A10) => R10)
@@ -227,6 +258,8 @@ export type DecreasingConstructorOverloadsInfoUnion<ConstructorType> = Construct
  * {@linkcode ConstructorType}. Does a check for whether we can do the
  * one-shot 10-overload matcher (which works for ts>5.3), and if not,
  * falls back to the more complicated utility.
+ *
+ * @internal
  */
 export type ConstructorOverloadsUnion<ConstructorType> =
   // recent TypeScript versions (5.3+) can treat a 1-overload type constructor as a 10-overload. Test for this by seeing if we can successfully get a union from a 1-overload constructor. If we can't, we're on an old TypeScript and need to use the more complicated utility.
@@ -234,18 +267,26 @@ export type ConstructorOverloadsUnion<ConstructorType> =
     ? TSPre53ConstructorOverloadsInfoUnion<ConstructorType>
     : TSPost53ConstructorOverloadsInfoUnion<ConstructorType>
 
-/** Allows inferring any constructor using the `infer` keyword. */
+/**
+ * Allows inferring any constructor using the `infer` keyword.
+ *
+ * @internal
+ */
 // This *looks* fairly pointless but if you try to use `new (...args: any) => any` directly, TypeScript will not infer the constructor type correctly.
 export type InferConstructor<ConstructorType extends new (...args: any) => any> = ConstructorType
 
 /**
  * A union type of the parameters allowed for any overload
  * of constructor {@linkcode ConstructorType}.
+ *
+ * @internal
  */
 export type ConstructorOverloadParameters<ConstructorType> =
   ConstructorOverloadsUnion<ConstructorType> extends InferConstructor<infer Ctor> ? ConstructorParameters<Ctor> : never
 
 /**
  * Calculates the number of overloads for a given function type.
+ *
+ * @internal
  */
 export type NumOverloads<FunctionType> = UnionToTuple<OverloadsInfoUnion<FunctionType>>['length']

--- a/src/overloads.ts
+++ b/src/overloads.ts
@@ -10,8 +10,6 @@ import {StrictEqualUsingTSInternalIdenticalToOperator, IsNever, UnionToIntersect
  *
  * For older versions of TypeScript, we'll need to painstakingly do
  * ten separate matches.
- *
- * @internal
  */
 export type TSPost53OverloadsInfoUnion<FunctionType> =
   FunctionType extends {(...args: infer A1): infer R1; (...args: infer A2): infer R2; (...args: infer A3): infer R3; (...args: infer A4): infer R4; (...args: infer A5): infer R5; (...args: infer A6): infer R6; (...args: infer A7): infer R7; (...args: infer A8): infer R8; (...args: infer A9): infer R9; (...args: infer A10): infer R10}
@@ -20,8 +18,6 @@ export type TSPost53OverloadsInfoUnion<FunctionType> =
 
 /**
  * A function with `unknown` parameters and return type.
- *
- * @internal
  */
 export type UnknownFunction = (...args: unknown[]) => unknown
 
@@ -33,8 +29,6 @@ export type UnknownFunction = (...args: unknown[]) => unknown
  * 9 "useless" overloads and one real one for parameterless/generic functions.
  *
  * @see {@link https://github.com/microsoft/TypeScript/issues/28867 | Related}
- *
- * @internal
  */
 export type IsUselessOverloadInfo<FunctionType> = StrictEqualUsingTSInternalIdenticalToOperator<
   FunctionType,
@@ -47,8 +41,6 @@ export type IsUselessOverloadInfo<FunctionType> = StrictEqualUsingTSInternalIden
  * extra `infer X` expression. There may be a better way to work around this
  * problem, but since it's not a problem in newer versions of TypeScript,
  * it's not a priority right now.
- *
- * @internal
  */
 export type Tuplify<Union> = Union extends infer X ? [X] : never
 
@@ -62,8 +54,6 @@ export type Tuplify<Union> = Union extends infer X ? [X] : never
  * {@linkcode IsUselessOverloadInfo} to remove useless overloads.
  *
  * @see {@link https://github.com/microsoft/TypeScript/issues/28867 | Related}
- *
- * @internal
  */
 export type TSPre53OverloadsInfoUnion<FunctionType> =
   // first, pointlessly wrap the overload variants in a 1-tuple, then infer them as `Tup` - this helps TypeScript isolate out the overload variants
@@ -82,8 +72,6 @@ export type TSPre53OverloadsInfoUnion<FunctionType> =
 /**
  * For versions of TypeScript below 5.3, we need to check for 10 overloads,
  * then 9, then 8, etc., to get a union of the overload variants.
- *
- * @internal
  */
 export type DecreasingOverloadsInfoUnion<F> = F extends {(...args: infer A1): infer R1; (...args: infer A2): infer R2; (...args: infer A3): infer R3; (...args: infer A4): infer R4; (...args: infer A5): infer R5; (...args: infer A6): infer R6; (...args: infer A7): infer R7; (...args: infer A8): infer R8; (...args: infer A9): infer R9; (...args: infer A10): infer R10}
   ? ((...p: A1) => R1) | ((...p: A2) => R2) | ((...p: A3) => R3) | ((...p: A4) => R4) | ((...p: A5) => R5) | ((...p: A6) => R6) | ((...p: A7) => R7) | ((...p: A8) => R8) | ((...p: A9) => R9) | ((...p: A10) => R10)
@@ -111,8 +99,6 @@ export type DecreasingOverloadsInfoUnion<F> = F extends {(...args: infer A1): in
  * Does a check for whether we can do the one-shot
  * 10-overload matcher (which works for ts\>5.3), and if not,
  * falls back to the more complicated utility.
- *
- * @internal
  */
 export type OverloadsInfoUnion<FunctionType> =
   // recent TypeScript versions (5.3+) can treat a 1-overload type function as a 10-overload. Test for this by seeing if we can successfully get a union from a 1-overload function. If we can't, we're on an old TypeScript and need to use the more complicated utility.
@@ -122,16 +108,12 @@ export type OverloadsInfoUnion<FunctionType> =
 
 /**
  * Allows inferring any function using the `infer` keyword.
- *
- * @internal
  */
 export type InferFunctionType<FunctionType extends (...args: any) => any> = FunctionType
 
 /**
  * A union type of the parameters allowed for any
  * overload of function {@linkcode FunctionType}.
- *
- * @internal
  */
 export type OverloadParameters<FunctionType> =
   OverloadsInfoUnion<FunctionType> extends InferFunctionType<infer Fn> ? Parameters<Fn> : never
@@ -139,8 +121,6 @@ export type OverloadParameters<FunctionType> =
 /**
  * A union type of the return types for any overload of
  * function {@linkcode FunctionType}.
- *
- * @internal
  */
 export type OverloadReturnTypes<FunctionType> =
   OverloadsInfoUnion<FunctionType> extends InferFunctionType<infer Fn> ? ReturnType<Fn> : never
@@ -149,8 +129,6 @@ export type OverloadReturnTypes<FunctionType> =
  * Takes an overload variants {@linkcode Union},
  * produced from {@linkcode OverloadsInfoUnion} and rejects
  * the ones incompatible with parameters {@linkcode Args}.
- *
- * @internal
  */
 export type SelectOverloadsInfo<Union extends UnknownFunction, Args extends unknown[]> =
   Union extends InferFunctionType<infer Fn> ? (Args extends Parameters<Fn> ? Fn : never) : never
@@ -159,8 +137,6 @@ export type SelectOverloadsInfo<Union extends UnknownFunction, Args extends unkn
  * Creates a new overload (an intersection type) from an existing one,
  * which only includes variant(s) which can accept
  * {@linkcode Args} as parameters.
- *
- * @internal
  */
 export type OverloadsNarrowedByParameters<
   FunctionType,
@@ -179,8 +155,6 @@ export type OverloadsNarrowedByParameters<
  *
  * For older versions of TypeScript,
  * we'll need to painstakingly do ten separate matches.
- *
- * @internal
  */
 export type TSPost53ConstructorOverloadsInfoUnion<ConstructorType> =
   ConstructorType extends {new (...args: infer A1): infer R1; new (...args: infer A2): infer R2; new (...args: infer A3): infer R3; new (...args: infer A4): infer R4; new (...args: infer A5): infer R5; new (...args: infer A6): infer R6; new (...args: infer A7): infer R7; new (...args: infer A8): infer R8; new (...args: infer A9): infer R9; new (...args: infer A10): infer R10}
@@ -189,16 +163,12 @@ export type TSPost53ConstructorOverloadsInfoUnion<ConstructorType> =
 
 /**
  * A constructor function with `unknown` parameters and return type.
- *
- * @internal
  */
 export type UnknownConstructor = new (...args: unknown[]) => unknown
 
 // prettier-ignore
 /**
  * Same as {@linkcode IsUselessOverloadInfo}, but for constructors.
- *
- * @internal
  */
 export type IsUselessConstructorOverloadInfo<FunctionType> = StrictEqualUsingTSInternalIdenticalToOperator<FunctionType, UnknownConstructor>
 
@@ -212,8 +182,6 @@ export type IsUselessConstructorOverloadInfo<FunctionType> = StrictEqualUsingTSI
  * {@linkcode IsUselessConstructorOverloadInfo} to remove useless overloads.
  *
  * @see {@link https://github.com/microsoft/TypeScript/issues/28867 | Related}
- *
- * @internal
  */
 export type TSPre53ConstructorOverloadsInfoUnion<ConstructorType> =
   // first, pointlessly wrap the overload variants in a 1-tuple, then infer them as `Tup` - this helps TypeScript isolate out the overload variants
@@ -232,8 +200,6 @@ export type TSPre53ConstructorOverloadsInfoUnion<ConstructorType> =
 /**
  * For versions of TypeScript below 5.3, we need to check for 10 overloads,
  * then 9, then 8, etc., to get a union of the overload variants.
- *
- * @internal
  */
 export type DecreasingConstructorOverloadsInfoUnion<ConstructorType> = ConstructorType extends {new (...args: infer A1): infer R1; new (...args: infer A2): infer R2; new (...args: infer A3): infer R3; new (...args: infer A4): infer R4; new (...args: infer A5): infer R5; new (...args: infer A6): infer R6; new (...args: infer A7): infer R7; new (...args: infer A8): infer R8; new (...args: infer A9): infer R9; new (...args: infer A10): infer R10}
   ? (new (...p: A1) => R1) | (new (...p: A2) => R2) | (new (...p: A3) => R3) | (new (...p: A4) => R4) | (new (...p: A5) => R5) | (new (...p: A6) => R6) | (new (...p: A7) => R7) | (new (...p: A8) => R8) | (new (...p: A9) => R9) | (new (...p: A10) => R10)
@@ -261,8 +227,6 @@ export type DecreasingConstructorOverloadsInfoUnion<ConstructorType> = Construct
  * {@linkcode ConstructorType}. Does a check for whether we can do the
  * one-shot 10-overload matcher (which works for ts\>5.3), and if not,
  * falls back to the more complicated utility.
- *
- * @internal
  */
 export type ConstructorOverloadsUnion<ConstructorType> =
   // recent TypeScript versions (5.3+) can treat a 1-overload type constructor as a 10-overload. Test for this by seeing if we can successfully get a union from a 1-overload constructor. If we can't, we're on an old TypeScript and need to use the more complicated utility.
@@ -272,8 +236,6 @@ export type ConstructorOverloadsUnion<ConstructorType> =
 
 /**
  * Allows inferring any constructor using the `infer` keyword.
- *
- * @internal
  */
 // This *looks* fairly pointless but if you try to use `new (...args: any) => any` directly, TypeScript will not infer the constructor type correctly.
 export type InferConstructor<ConstructorType extends new (...args: any) => any> = ConstructorType
@@ -281,15 +243,11 @@ export type InferConstructor<ConstructorType extends new (...args: any) => any> 
 /**
  * A union type of the parameters allowed for any overload
  * of constructor {@linkcode ConstructorType}.
- *
- * @internal
  */
 export type ConstructorOverloadParameters<ConstructorType> =
   ConstructorOverloadsUnion<ConstructorType> extends InferConstructor<infer Ctor> ? ConstructorParameters<Ctor> : never
 
 /**
  * Calculates the number of overloads for a given function type.
- *
- * @internal
  */
 export type NumOverloads<FunctionType> = UnionToTuple<OverloadsInfoUnion<FunctionType>>['length']

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -132,7 +132,7 @@ export type ExtendsExcludingAnyOrNever<Left, Right> = IsAny<Left> extends true ?
  * Checks if two types are strictly equal using
  * the TypeScript internal identical-to operator.
  *
- * @see {@link https://github.com/microsoft/TypeScript/issues/55188#issuecomment-1656328122 much history}
+ * @see {@link https://github.com/microsoft/TypeScript/issues/55188#issuecomment-1656328122 | much history}
  */
 export type StrictEqualUsingTSInternalIdenticalToOperator<L, R> =
   (<T>() => T extends (L & T) | T ? true : false) extends <T>() => T extends (R & T) | T ? true : false
@@ -162,6 +162,8 @@ type Mismatch = {[mismatch]: 'mismatch'}
 /**
  * A type which should match anything passed as a value but *doesn't*
  * match {@linkcode Mismatch}. It helps TypeScript select the right overload
+ * for {@linkcode PositiveExpectTypeOf.toEqualTypeOf | .toEqualTypeOf()} and
+ * {@linkcode PositiveExpectTypeOf.toMatchTypeOf | .toMatchTypeOf()}.
  *
  * @internal
  */

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -197,7 +197,7 @@ export interface ExpectTypeOfOptions {
 
 /**
  * Convert a union to an intersection.
- * `A | B | C` -> `A & B & C`
+ * `A | B | C` -\> `A & B & C`
  */
 export type UnionToIntersection<Union> = (Union extends any ? (distributedUnion: Union) => void : never) extends (
   mergedIntersection: infer Intersection,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -28,7 +28,14 @@ export type Eq<Left extends boolean, Right extends boolean> = Left extends true 
  */
 export type Xor<Types extends [boolean, boolean]> = Not<Eq<Types[0], Types[1]>>
 
+/**
+ * @internal
+ */
 const secret = Symbol('secret')
+
+/**
+ * @internal
+ */
 type Secret = typeof secret
 
 /**
@@ -103,6 +110,8 @@ export type ReadonlyKeys<T> = Extract<{
 // prettier-ignore
 /**
  * Determines if two types, are equivalent in a `readonly` manner.
+ *
+ * @internal
  */
 type ReadonlyEquivalent<X, Y> = Extends<
   (<T>() => T extends X ? true : false), (<T>() => T extends Y ? true : false)
@@ -140,14 +149,21 @@ export type StrictEqualUsingTSInternalIdenticalToOperator<L, R> =
  */
 export type MutuallyExtends<Left, Right> = And<[Extends<Left, Right>, Extends<Right, Left>]>
 
+/**
+ * @internal
+ */
 const mismatch = Symbol('mismatch')
+
+/**
+ * @internal
+ */
 type Mismatch = {[mismatch]: 'mismatch'}
 
 /**
  * A type which should match anything passed as a value but *doesn't*
  * match {@linkcode Mismatch}. It helps TypeScript select the right overload
- * for {@linkcode PositiveExpectTypeOf.toEqualTypeOf `.toEqualTypeOf()`} and
- * {@linkcode PositiveExpectTypeOf.toMatchTypeOf `.toMatchTypeOf()`}.
+ *
+ * @internal
  */
 const avalue = Symbol('avalue')
 


### PR DESCRIPTION
## **This PR**:

- [X] Marks internal APIs with `@internal` JSDoc tag.
- [X] Resolves #103.