### PR TITLE
Introduce the `.readonly()` method

### DIFF
--- a/README.md
+++ b/README.md
@@ -398,6 +398,14 @@ type Person = {name: string; age: number}
 expectTypeOf<Person>().omit<'name'>().toEqualTypeOf<{age: number}>()
 ```
 
+Use `.readonly` to create a `readonly` version of a type:
+
+```typescript
+type Post = {title: string; content: string}
+
+expectTypeOf<Post>().readonly().toEqualTypeOf<Readonly<Post>>()
+```
+
 Make assertions about object properties:
 
 ```typescript

--- a/src/index.ts
+++ b/src/index.ts
@@ -878,6 +878,30 @@ export interface BaseExpectTypeOf<Actual, Options extends {positive: boolean}> {
   ) => ExpectTypeOf<Omit<Actual, KeyToOmit>, Options>
 
   /**
+   * Converts all properties of a type to **`readonly`**,
+   * behaving exactly like the TypeScript {@linkcode Readonly} utility type.
+   *
+   * @example
+   * <caption>#### Create a **`readonly`** version of a type</caption>
+   *
+   * ```ts
+   * import { expectTypeOf } from 'expect-type'
+   *
+   * type Post = {
+   *   title: string
+   *   content: string
+   * }
+   *
+   * expectTypeOf<Post>().readonly().toEqualTypeOf<Readonly<Post>>()
+   * ```
+   *
+   * @returns The type with all properties made **`readonly`**, mirroring the behavior of TypeScript's {@linkcode Readonly} utility.
+   *
+   * @since 1.2.0
+   */
+  readonly(): ExpectTypeOf<Readonly<Actual>, Options>
+
+  /**
    * Extracts a certain function argument with `.parameter(number)` call to
    * perform other assertions on it.
    *
@@ -1150,6 +1174,7 @@ export const expectTypeOf: _ExpectTypeOf = <Actual>(
     exclude: expectTypeOf,
     pick: expectTypeOf,
     omit: expectTypeOf,
+    readonly: expectTypeOf,
     toHaveProperty: expectTypeOf,
     parameter: expectTypeOf,
     get branded() {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -120,7 +120,7 @@ type ReadonlyEquivalent<X, Y> = Extends<
 /**
  * Checks if one type extends another. Note: this is not quite the same as `Left extends Right` because:
  * 1. If either type is `never`, the result is `true` iff the other type is also `never`.
- * 2. Types are wrapped in a 1-tuple so that union types are not distributed - instead we consider `string | number` to _not_ extend `number`. If we used `Left extends Right` directly you would get `Extends<string | number, number>` => `false | true` => `boolean`.
+ * 2. Types are wrapped in a 1-tuple so that union types are not distributed - instead we consider `string | number` to _not_ extend `number`. If we used `Left extends Right` directly you would get `Extends<string | number, number>` =\> `false | true` =\> `boolean`.
  */
 export type Extends<Left, Right> = IsNever<Left> extends true ? IsNever<Right> : [Left] extends [Right] ? true : false
 

--- a/test/usage.test.ts
+++ b/test/usage.test.ts
@@ -293,6 +293,12 @@ test('Use `.omit` to remove a set of properties from an object', () => {
   expectTypeOf<Person>().omit<'name'>().toEqualTypeOf<{age: number}>()
 })
 
+test('Use `.readonly` to create a `readonly` version of a type', () => {
+  type Post = {title: string; content: string}
+
+  expectTypeOf<Post>().readonly().toEqualTypeOf<Readonly<Post>>()
+})
+
 test('Make assertions about object properties', () => {
   const obj = {a: 1, b: ''}
 


### PR DESCRIPTION
## **This PR**:

- [X] Introduces the `.readonly()` method for transforming object properties to `readonly`.

## **Details**:

`.readonly()` works similarly to the native `Readonly` utility type:

```ts
import { expectTypeOf } from 'expect-type'

type Post = {
  title: string
  content: string
}

expectTypeOf<Post>().readonly().toEqualTypeOf<Readonly<Post>>()
```