### PR TITLE
bigint printtype

### DIFF
--- a/README.md
+++ b/README.md
@@ -332,6 +332,7 @@ type Factorize = {
   (input: bigint): bigint[]
 }
 
+expectTypeOf<Factorize>().parameters.not.toEqualTypeOf<[number]>()
 expectTypeOf<Factorize>().parameters.toEqualTypeOf<[number] | [bigint]>()
 expectTypeOf<Factorize>().returns.toEqualTypeOf<number[] | bigint[]>()
 

--- a/src/messages.ts
+++ b/src/messages.ts
@@ -23,13 +23,17 @@ export type PrintType<T> =
                   ? 'number'
                   : T extends number
                     ? `literal number: ${T}`
-                    : T extends null
-                      ? 'null'
-                      : T extends undefined
-                        ? 'undefined'
-                        : T extends (...args: any[]) => any
-                          ? 'function'
-                          : '...'
+                    : bigint extends T
+                      ? 'bigint'
+                      : T extends bigint
+                        ? `literal bigint: ${T}`
+                        : T extends null
+                          ? 'null'
+                          : T extends undefined
+                            ? 'undefined'
+                            : T extends (...args: any[]) => any
+                              ? 'function'
+                              : '...'
 
 /**
  * Helper for showing end-user a hint why their type assertion is failing.

--- a/test/__snapshots__/errors.test.ts.snap
+++ b/test/__snapshots__/errors.test.ts.snap
@@ -126,6 +126,12 @@ test/usage.test.ts:999:999 - error TS2344: Type 'HasParam' does not satisfy the 
 
 999   expectTypeOf<NoParam>().toEqualTypeOf<HasParam>()
                                             ~~~~~~~~
+test/usage.test.ts:999:999 - error TS2344: Type '[number]' does not satisfy the constraint '{ 0: "Expected: number, Actual: bigint"; }'.
+  Types of property '0' are incompatible.
+    Type 'number' is not assignable to type '"Expected: number, Actual: bigint"'.
+
+999   expectTypeOf<Factorize>().parameters.toEqualTypeOf<[number]>()
+                                                         ~~~~~~~~
 test/usage.test.ts:999:999 - error TS2349: This expression is not callable.
   Type 'ExpectAny<(a: number) => number[]>' has no call signatures.
 

--- a/test/usage.test.ts
+++ b/test/usage.test.ts
@@ -222,6 +222,7 @@ test('Up to ten overloads will produce union types for `.parameters` and `.retur
     (input: bigint): bigint[]
   }
 
+  expectTypeOf<Factorize>().parameters.not.toEqualTypeOf<[number]>()
   expectTypeOf<Factorize>().parameters.toEqualTypeOf<[number] | [bigint]>()
   expectTypeOf<Factorize>().returns.toEqualTypeOf<number[] | bigint[]>()
 


### PR DESCRIPTION
CC @aryaemami59 noticed during my demo that we get not-v-useful `Expected: ..., Actual: number` messages when the error involves a bigint. Since we have official bigint support now thought that should be addressed before it's shipped.

View without whitespace: https://github.com/mmkal/expect-type/pull/125/files?w=1