### PR TITLE
toMatchObjectType + toExtend - replacements for toMatchTypeOf

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -227,3 +227,7 @@ export type TuplifyUnion<Union, LastElement = LastOf<Union>> =
  * Convert a union like `1 | 2 | 3` to a tuple like `[1, 2, 3]`.
  */
 export type UnionToTuple<Union> = TuplifyUnion<Union>
+
+export type IsTuple<T> = Or<[Extends<T, []>, Extends<T, [any, ...any[]]>]>
+
+export type IsUnion<T> = Not<Extends<UnionToTuple<T>['length'], 1>>

--- a/test/__snapshots__/errors.test.ts.snap
+++ b/test/__snapshots__/errors.test.ts.snap
@@ -6,6 +6,11 @@ exports[`usage.test.ts 1`] = `
 
 999   expectTypeOf({a: 1, b: 1}).toEqualTypeOf<{a: number}>()
                                                ~~~~~~~~~~~
+test/usage.test.ts:999:999 - error TS2344: Type '{ b: number; }' does not satisfy the constraint '{ a: "Expected: never, Actual: number"; b: "Expected: number, Actual: never"; }'.
+  Property 'a' is missing in type '{ b: number; }' but required in type '{ a: "Expected: never, Actual: number"; b: "Expected: number, Actual: never"; }'.
+
+999   expectTypeOf<{a: number}>().toExtend<{b: number}>()
+                                           ~~~~~~~~~~~
 test/usage.test.ts:999:999 - error TS2344: Type '{ a: number; b: number; }' does not satisfy the constraint '{ a: number; b: "Expected: number, Actual: never"; }'.
   Types of property 'b' are incompatible.
     Type 'number' is not assignable to type '"Expected: number, Actual: never"'.
@@ -16,29 +21,40 @@ test/usage.test.ts:999:999 - error TS2344: Type '{ a: number; b: number; }' does
   Types of property 'b' are incompatible.
     Type 'number' is not assignable to type '"Expected: number, Actual: never"'.
 
-999   expectTypeOf({a: 1}).toMatchTypeOf<{a: number; b: number}>()
-                                         ~~~~~~~~~~~~~~~~~~~~~~
+999   expectTypeOf({a: 1}).toExtend<{a: number; b: number}>()
+                                    ~~~~~~~~~~~~~~~~~~~~~~
 test/usage.test.ts:999:999 - error TS2344: Type 'Apple' does not satisfy the constraint '{ name: "Expected: literal string: Apple, Actual: never"; type: "Fruit"; edible: "Expected: literal boolean: true, Actual: literal boolean: false"; }'.
   Types of property 'name' are incompatible.
     Type '"Apple"' is not assignable to type '"Expected: literal string: Apple, Actual: never"'.
 
-999   expectTypeOf<Fruit>().toMatchTypeOf<Apple>()
-                                          ~~~~~
+999   expectTypeOf<Fruit>().toExtend<Apple>()
+                                     ~~~~~
+test/usage.test.ts:999:999 - error TS2344: Type 'Fruit' does not satisfy the constraint '{ type: "Fruit"; edible: "Expected: boolean, Actual: never"; }'.
+  Types of property 'edible' are incompatible.
+    Type 'boolean' is not assignable to type '"Expected: boolean, Actual: never"'.
+
+999   expectTypeOf<Apple>().toMatchObjectType<Fruit>()
+                                              ~~~~~
 test/usage.test.ts:999:999 - error TS2344: Type 'Fruit' does not satisfy the constraint '{ name: "Expected: never, Actual: literal string: Apple"; type: "Fruit"; edible: "Expected: boolean, Actual: never"; }'.
   Property 'name' is missing in type 'Fruit' but required in type '{ name: "Expected: never, Actual: literal string: Apple"; type: "Fruit"; edible: "Expected: boolean, Actual: never"; }'.
 
 999   expectTypeOf<Apple>().toEqualTypeOf<Fruit>()
                                           ~~~~~
-test/usage.test.ts:999:999 - error TS2554: Expected 0 arguments, but got 1.
+test/usage.test.ts:999:999 - error TS2344: Type '{ b: 1; }' does not satisfy the constraint '{ a: "Expected: never, Actual: number"; b: "Expected: literal number: 1, Actual: never"; }'.
+  Property 'a' is missing in type '{ b: 1; }' but required in type '{ a: "Expected: never, Actual: number"; b: "Expected: literal number: 1, Actual: never"; }'.
 
-999   expectTypeOf({a: 1}).toMatchTypeOf({b: 1})
-                                         ~~~~~~
+999   expectTypeOf({a: 1}).toExtend<{b: 1}>()
+                                    ~~~~~~
+test/usage.test.ts:999:999 - error TS2344: Type '{ b: 1; }' does not satisfy the constraint '"Expected: ..., Actual: boolean"'.
+
+999   expectTypeOf({a: 1}).toMatchObjectType<{b: 1}>()
+                                             ~~~~~~
 test/usage.test.ts:999:999 - error TS2344: Type 'Apple' does not satisfy the constraint '{ name: "Expected: literal string: Apple, Actual: never"; type: "Fruit"; edible: "Expected: literal boolean: true, Actual: literal boolean: false"; }'.
   Types of property 'name' are incompatible.
     Type '"Apple"' is not assignable to type '"Expected: literal string: Apple, Actual: never"'.
 
-999   expectTypeOf<Fruit>().toMatchTypeOf<Apple>()
-                                          ~~~~~
+999   expectTypeOf<Fruit>().toExtend<Apple>()
+                                     ~~~~~
 test/usage.test.ts:999:999 - error TS2344: Type 'Fruit' does not satisfy the constraint '{ name: "Expected: never, Actual: literal string: Apple"; type: "Fruit"; edible: "Expected: boolean, Actual: never"; }'.
   Property 'name' is missing in type 'Fruit' but required in type '{ name: "Expected: never, Actual: literal string: Apple"; type: "Fruit"; edible: "Expected: boolean, Actual: never"; }'.
 
@@ -107,8 +123,8 @@ test/usage.test.ts:999:999 - error TS2349: This expression is not callable.
                       ~~~~~~~~~~
 test/usage.test.ts:999:999 - error TS2344: Type 'number' does not satisfy the constraint '"Expected: number, Actual: string"'.
 
-999   expectTypeOf<string | number>().toMatchTypeOf<number>()
-                                                    ~~~~~~
+999   expectTypeOf<string | number>().toExtend<number>()
+                                               ~~~~~~
 test/usage.test.ts:999:999 - error TS2345: Argument of type '"xxl"' is not assignable to parameter of type '"xs" | "sm" | "md"'.
 
 999   expectTypeOf<ResponsiveProp<number>>().exclude<number | number[]>().toHaveProperty('xxl')
@@ -284,20 +300,5 @@ test/usage.test.ts:999:999 - error TS2769: No overload matches this call.
   Argument of type '[this]' is not assignable to parameter of type 'MismatchArgs<StrictEqualUsingTSInternalIdenticalToOperator<this, StrictEqualUsingTSInternalIdenticalToOperator<this, unknown> extends true ? unknown : MismatchInfo<this, unknown>>, true>'.
 
 999       expectTypeOf(this).toEqualTypeOf(this)
-                                           ~~~~
-
-test/usage.test.ts:999:999 - error TS2769: No overload matches this call.
-  Overload 1 of 2, '(value: (Extends<this, this> extends true ? unknown : MismatchInfo<this, this>) & AValue, ...MISMATCH: MismatchArgs<Extends<this, Extends<this, this> extends true ? unknown : MismatchInfo<...>>, true>): true', gave the following error.
-    Argument of type 'this' is not assignable to parameter of type '(Extends<this, this> extends true ? unknown : MismatchInfo<this, this>) & AValue'.
-      Type 'B' is not assignable to type '(Extends<this, this> extends true ? unknown : MismatchInfo<this, this>) & AValue'.
-        Type 'B' is not assignable to type '(Extends<this, this> extends true ? unknown : MismatchInfo<this, this>) & { [avalue]?: undefined; }'.
-          Type 'this' is not assignable to type '(Extends<this, this> extends true ? unknown : MismatchInfo<this, this>) & { [avalue]?: undefined; }'.
-            Type 'B' is not assignable to type '(Extends<this, this> extends true ? unknown : MismatchInfo<this, this>) & { [avalue]?: undefined; }'.
-              Type 'B' is not assignable to type 'Extends<this, this> extends true ? unknown : MismatchInfo<this, this>'.
-                Type 'this' is not assignable to type 'Extends<this, this> extends true ? unknown : MismatchInfo<this, this>'.
-                  Type 'B' is not assignable to type 'Extends<this, this> extends true ? unknown : MismatchInfo<this, this>'.
-  Argument of type '[this]' is not assignable to parameter of type 'MismatchArgs<Extends<this, Extends<this, unknown> extends true ? unknown : MismatchInfo<this, unknown>>, true>'.
-
-999       expectTypeOf(this).toMatchTypeOf(this)
                                            ~~~~"
 `;

--- a/test/types.test.ts
+++ b/test/types.test.ts
@@ -847,3 +847,14 @@ test('Overload edge cases', () => {
   expectTypeOf<NoArgOverload>().parameters.toEqualTypeOf<[] | [1]>()
   expectTypeOf<NoArgOverload>().returns.toEqualTypeOf<1>()
 })
+
+test('toMatchObjectType', () => {
+  expectTypeOf<{a: number}>().toMatchObjectType<{a: number}>()
+  expectTypeOf<{a: number}>().not.toMatchObjectType<{a: string}>()
+  expectTypeOf({a: 1, b: 2}).toMatchObjectType<{a: number}>()
+
+  // @ts-expect-error
+  expectTypeOf<any>().toMatchObjectType<number>()
+  // @ts-expect-error
+  expectTypeOf<{a: number}>().toMatchObjectType<{a: string} | {a: number}>()
+})


### PR DESCRIPTION
Closes #55 (if merged, collecting feedback first)

This introduces two new methods to replace the ever-controversial `toMatchTypeOf`, which would be deprecated by this change. It won't be removed until v2, but no plans for that any time soon.

- `toExtend` - does what `toMatchTypeOf` used to do - basically just check `Actual extends Expected`
- `toMatchObjectType` - does a `Pick<...>` of actual, so you can do precise checks on a subset of your type's keys:

```ts
type MyType = {readonly a: string; b: number; c: {some: {very: {complex: 'type'}}}; d: 'another type'}

expectTypeOf<MyType>().toMatchObjectType<{a: string; b: number}>() // fails - forgot readonly
expectTypeOf<MyType>().toMatchObjectType<{readonly a: string; b?: number}>() // passes
```

Note: `toMatchObjectType` only accepts plain object expectations - no unions, no tuples, no primitives

I suspect most instances of `.toMatchTypeOf` could be happily replaced by `.toMatchObjectType`, and the word "object" being in the name makes it a bit clearer what's happening - and it is closer to a compile-time version of the jest `.toMatchObject` method.

In the remainder of cases, people can reach for `toExtend` - though this one should be more rarely used, because `extends` is a fairly weak assertion (and, in fact, you can achieve something similar with `{} as MyType satisfies {a: string}`, without using any library.


