### PR TITLE
ci: fix TypeScript v5.0 installation issue during CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,12 +23,13 @@ jobs:
     name: Test Types with TypeScript ${{ matrix.ts }}
     strategy:
       matrix:
-        ts: [4.7, 4.8, 4.9, 5.0, 5.1, 5.2, 5.3, 5.4, 5.5]
+        ts: ["4.7", "4.8", "4.9", "5.0", "5.1", "5.2", "5.3", "5.4", "5.5"]
     steps:
       - uses: actions/checkout@v4
       - run: corepack enable
       - run: pnpm install
       - run: pnpm install typescript@${{ matrix.ts }}
+      - run: pnpm list typescript
       - run: pnpm type-check
 
   are-the-types-wrong:


### PR DESCRIPTION
## Overview

During CI, the `test-types` job encounters an issue where specifying `typescript@5.0` results in the `.0` being truncated. Consequently, `pnpm` installs `typescript@v5`, which resolves to the latest version (currently `v5.6.2`) instead of the intended `5.0.4`.

---

## **This PR**:

- [X] Wraps the TypeScript version numbers in strings to resolve the issue.