### PR TITLE
chore: add TypeScript 5.6 and 5.7 to testing matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,18 @@ jobs:
     name: Test Types with TypeScript ${{ matrix.ts }}
     strategy:
       matrix:
-        ts: ["4.7", "4.8", "4.9", "5.0", "5.1", "5.2", "5.3", "5.4", "5.5"]
+        ts:
+          - "4.7"
+          - "4.8"
+          - "4.9"
+          - "5.0"
+          - "5.1"
+          - "5.2"
+          - "5.3"
+          - "5.4"
+          - "5.5"
+          - "5.6"
+          - "5.7"
     steps:
       - uses: actions/checkout@v4
       - run: corepack enable


### PR DESCRIPTION
## **This PR**:

- [X] Adds TypeScript 5.6 and 5.7 to testing matrix.