### PR TITLE
Update jsdoc

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -49,6 +49,16 @@ export interface PositiveExpectTypeOf<Actual> extends BaseExpectTypeOf<Actual, {
    * Deeply "picks" the properties of the actual type based on the expected type, then performs a strict check to make sure the types match `Expected`.
    *
    * Note: optional properties on the expected type are not allowed to be missing on the actual type.
+   *
+   * @example
+   * ```ts
+   * expectTypeOf({ a: 1, b: 1 }).toMatchObjectType<{ a: number }>()
+   *
+   * expectTypeOf({ a: 1, b: 1 }).not.toMatchObjectType<{ a: number; c?: number }>()
+   * ```
+   *
+   * @param MISMATCH - The mismatch arguments.
+   * @returns `true`.
    */
   toMatchObjectType: <
     Expected extends IsUnion<Expected> extends true
@@ -317,11 +327,17 @@ export interface NegativeExpectTypeOf<Actual> extends BaseExpectTypeOf<Actual, {
    * Similar to jest's `expect(...).toMatchObject(...)` but for types.
    * Deeply "picks" the properties of the actual type based on the expected type, then performs a strict check to make sure the types match `Expected`.
    *
+   * Note: optional properties on the expected type are not allowed to be missing on the actual type.
+   *
    * @example
    * ```ts
-   * expectTypeOf({a: 1, b: 2}).toMatchObjectType<{a: number}> // passes
-   * expectTypeOf({a: 1, b: 2}).toMatchObjectType<{a: string}> // fails
+   * expectTypeOf({ a: 1, b: 1 }).toMatchObjectType<{ a: number }>()
+   *
+   * expectTypeOf({ a: 1, b: 1 }).not.toMatchObjectType<{ a: number; c?: number }>()
    * ```
+   *
+   * @param MISMATCH - The mismatch arguments.
+   * @returns `true`.
    */
   toMatchObjectType: <Expected>(
     ...MISMATCH: MismatchArgs<

--- a/src/index.ts
+++ b/src/index.ts
@@ -75,9 +75,25 @@ export interface PositiveExpectTypeOf<Actual> extends BaseExpectTypeOf<Actual, {
     >
   ) => true
 
-  toExtend<Expected extends Extends<Actual, Expected> extends true ? unknown : MismatchInfo<Actual, Expected>>(
+  /**
+   * Check if your type extends the expected type
+   *
+   * A less strict version of {@linkcode toEqualTypeOf | .toEqualTypeOf()} that allows for extra properties.
+   * This is roughly equivalent to an `extends` constraint in a function type argument.
+   *
+   * @example
+   * ```ts
+   * expectTypeOf({ a: 1, b: 1 }).toExtend<{ a: number }>()
+   *
+   * expectTypeOf({ a: 1 }).not.toExtend<{ b: number }>()
+   * ```
+   *
+   * @param MISMATCH - The mismatch arguments.
+   * @returns `true`.
+   */
+  toExtend: <Expected extends Extends<Actual, Expected> extends true ? unknown : MismatchInfo<Actual, Expected>>(
     ...MISMATCH: MismatchArgs<Extends<Actual, Expected>, true>
-  ): true
+  ) => true
 
   toEqualTypeOf: {
     /**
@@ -160,10 +176,6 @@ export interface PositiveExpectTypeOf<Actual> extends BaseExpectTypeOf<Actual, {
       ...MISMATCH: MismatchArgs<StrictEqualUsingTSInternalIdenticalToOperator<Actual, Expected>, true>
     ): true
   }
-
-  toExtend: <Expected extends Extends<Actual, Expected> extends true ? unknown : MismatchInfo<Actual, Expected>>(
-    ...MISMATCH: MismatchArgs<Extends<Actual, Expected>, true>
-  ) => true
 
   /**
    * @deprecated - use either `toMatchObjectType` or `toExtend` instead
@@ -346,6 +358,22 @@ export interface NegativeExpectTypeOf<Actual> extends BaseExpectTypeOf<Actual, {
     >
   ) => true
 
+  /**
+   * Check if your type extends the expected type
+   *
+   * A less strict version of {@linkcode PositiveExpectTypeOf.toEqualTypeOf | .toEqualTypeOf()} that allows for extra properties.
+   * This is roughly equivalent to an `extends` constraint in a function type argument.
+   *
+   * @example
+   * ```ts
+   * expectTypeOf({ a: 1, b: 1 }).toExtend<{ a: number }>()]
+   *
+   * expectTypeOf({ a: 1 }).not.toExtend<{ b: number }>()
+   * ```
+   *
+   * @param MISMATCH - The mismatch arguments.
+   * @returns `true`.
+   */
   toExtend<Expected>(...MISMATCH: MismatchArgs<Extends<Actual, Expected>, false>): true
 
   toEqualTypeOf: {

--- a/src/index.ts
+++ b/src/index.ts
@@ -404,8 +404,16 @@ export interface NegativeExpectTypeOf<Actual> extends BaseExpectTypeOf<Actual, {
     <Expected>(...MISMATCH: MismatchArgs<StrictEqualUsingTSInternalIdenticalToOperator<Actual, Expected>, false>): true
   }
 
+  /**
+   * @deprecated - use either `toMatchObjectType` or `toExtend` instead
+   * - use `toMatchObjectType` to perform a strict check on a subset of your type's keys
+   * - use `toExtend` to check if your type extends the expected type
+   */
   toMatchTypeOf: {
     /**
+     * @deprecated - use either `toMatchObjectType` or `toExtend` instead
+     * - use `toMatchObjectType` to perform a strict check on a subset of your type's keys
+     * - use `toExtend` to check if your type extends the expected type
      * A less strict version of
      * {@linkcode PositiveExpectTypeOf.toEqualTypeOf | .toEqualTypeOf()}
      * that allows for extra properties.
@@ -434,6 +442,9 @@ export interface NegativeExpectTypeOf<Actual> extends BaseExpectTypeOf<Actual, {
     ): true
 
     /**
+     * @deprecated - use either `toMatchObjectType` or `toExtend` instead
+     * - use `toMatchObjectType` to perform a strict check on a subset of your type's keys
+     * - use `toExtend` to check if your type extends the expected type
      * A less strict version of
      * {@linkcode PositiveExpectTypeOf.toEqualTypeOf | .toEqualTypeOf()}
      * that allows for extra properties.


### PR DESCRIPTION
This PR improves the JSDoc of `toExtend` / `toMatchObjectType` / `toMatchTypeOf`.

The included changes are:

- Removed duplicated `toExtend` property / method from `PositiveExpectTypeOf`: I'm not sure if this is fine. Was this for something related to variance? I ran the tests and it passed without it.
- Added JSDoc to `toExtend`
- Added example to the JSDoc of `toMatchObjectType` in `PositiveExpectTypeOf`
- Aligned the JSDoc content of `toMatchObjectType` between `PositiveExpectTypeOf` and `NegativeExpectTypeOf`
- Added `@deprecated` to `toMatchTypeOf` in `NegativeExpectTypeOf`
