### PR TITLE
Implement an explicit error message

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -564,72 +564,72 @@ export interface BaseExpectTypeOf<Actual, Options extends {positive: boolean}> {
   /**
    * Checks whether the type of the value is `any`.
    */
-  toBeAny: Scolder<ExpectAny<Actual>, Options>
+  toBeAny: Scolder<ExpectAny<Actual>, Options, 'any', Actual>
 
   /**
    * Checks whether the type of the value is `unknown`.
    */
-  toBeUnknown: Scolder<ExpectUnknown<Actual>, Options>
+  toBeUnknown: Scolder<ExpectUnknown<Actual>, Options, 'unknown', Actual>
 
   /**
    * Checks whether the type of the value is `never`.
    */
-  toBeNever: Scolder<ExpectNever<Actual>, Options>
+  toBeNever: Scolder<ExpectNever<Actual>, Options, 'never', Actual>
 
   /**
    * Checks whether the type of the value is `function`.
    */
-  toBeFunction: Scolder<ExpectFunction<Actual>, Options>
+  toBeFunction: Scolder<ExpectFunction<Actual>, Options, 'function', Actual>
 
   /**
    * Checks whether the type of the value is `object`.
    */
-  toBeObject: Scolder<ExpectObject<Actual>, Options>
+  toBeObject: Scolder<ExpectObject<Actual>, Options, 'object', Actual>
 
   /**
    * Checks whether the type of the value is an {@linkcode Array}.
    */
-  toBeArray: Scolder<ExpectArray<Actual>, Options>
+  toBeArray: Scolder<ExpectArray<Actual>, Options, 'array', Actual>
 
   /**
    * Checks whether the type of the value is `number`.
    */
-  toBeNumber: Scolder<ExpectNumber<Actual>, Options>
+  toBeNumber: Scolder<ExpectNumber<Actual>, Options, 'number', Actual>
 
   /**
    * Checks whether the type of the value is `string`.
    */
-  toBeString: Scolder<ExpectString<Actual>, Options>
+  toBeString: Scolder<ExpectString<Actual>, Options, 'string', Actual>
 
   /**
    * Checks whether the type of the value is `boolean`.
    */
-  toBeBoolean: Scolder<ExpectBoolean<Actual>, Options>
+  toBeBoolean: Scolder<ExpectBoolean<Actual>, Options, 'boolean', Actual>
 
   /**
    * Checks whether the type of the value is `void`.
    */
-  toBeVoid: Scolder<ExpectVoid<Actual>, Options>
+  toBeVoid: Scolder<ExpectVoid<Actual>, Options, 'void', Actual>
 
   /**
    * Checks whether the type of the value is `symbol`.
    */
-  toBeSymbol: Scolder<ExpectSymbol<Actual>, Options>
+  toBeSymbol: Scolder<ExpectSymbol<Actual>, Options, 'symbol', Actual>
 
   /**
    * Checks whether the type of the value is `null`.
    */
-  toBeNull: Scolder<ExpectNull<Actual>, Options>
+  toBeNull: Scolder<ExpectNull<Actual>, Options, 'null', Actual>
 
   /**
    * Checks whether the type of the value is `undefined`.
    */
-  toBeUndefined: Scolder<ExpectUndefined<Actual>, Options>
+  toBeUndefined: Scolder<ExpectUndefined<Actual>, Options, 'undefined', Actual>
 
   /**
    * Checks whether the type of the value is `null` or `undefined`.
    */
-  toBeNullable: Scolder<ExpectNullable<Actual>, Options>
+  toBeNullable: Scolder<ExpectNullable<Actual>, Options, 'nullable', Actual>
 
   /**
    * Transform that type of the value via a callback.
@@ -657,7 +657,7 @@ export interface BaseExpectTypeOf<Actual, Options extends {positive: boolean}> {
    *
    * @since 1.1.0
    */
-  toBeBigInt: Scolder<ExpectBigInt<Actual>, Options>
+  toBeBigInt: Scolder<ExpectBigInt<Actual>, Options, 'bigint', Actual>
 
   /**
    * Checks whether a function is callable with the given parameters.

--- a/test/__snapshots__/errors.test.ts.snap
+++ b/test/__snapshots__/errors.test.ts.snap
@@ -67,7 +67,7 @@ test/usage.test.ts:999:999 - error TS2344: Type 'Fruit' does not satisfy the con
 999   expectTypeOf<Apple>().toEqualTypeOf<Fruit>()
                                           ~~~~~
 test/usage.test.ts:999:999 - error TS2349: This expression is not callable.
-  Type 'ExpectNumber<never>' has no call signatures.
+  Type '{ "Expected: number, Actual: never": never; }' has no call signatures.
 
 999   expectTypeOf<never>().toBeNumber()
                             ~~~~~~~~~~
@@ -78,52 +78,52 @@ test/usage.test.ts:999:999 - error TS2344: Type '{ deeply: { nested: unknown; };
 999   expectTypeOf<{deeply: {nested: any}}>().toEqualTypeOf<{deeply: {nested: unknown}}>()
                                                             ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 test/usage.test.ts:999:999 - error TS2349: This expression is not callable.
-  Type 'ExpectNumber<any>' has no call signatures.
+  Type '{ "Expected: number, Actual: any": never; }' has no call signatures.
 
 999   expectTypeOf(badIntParser).returns.toBeNumber()
                                          ~~~~~~~~~~
 test/usage.test.ts:999:999 - error TS2349: This expression is not callable.
-  Type 'ExpectNull<undefined>' has no call signatures.
+  Type '{ "Expected: null, Actual: undefined": never; }' has no call signatures.
 
 999   expectTypeOf(undefined).toBeNull()
                               ~~~~~~~~
 test/usage.test.ts:999:999 - error TS2349: This expression is not callable.
-  Type 'ExpectUndefined<null>' has no call signatures.
+  Type '{ "Expected: undefined, Actual: null": never; }' has no call signatures.
 
 999   expectTypeOf(null).toBeUndefined()
                          ~~~~~~~~~~~~~
 test/usage.test.ts:999:999 - error TS2349: This expression is not callable.
-  Type 'ExpectUnknown<number>' has no call signatures.
+  Type '{ "Expected: unknown, Actual: number": never; }' has no call signatures.
 
 999   expectTypeOf(1).toBeUnknown()
                       ~~~~~~~~~~~
 test/usage.test.ts:999:999 - error TS2349: This expression is not callable.
-  Type 'ExpectAny<number>' has no call signatures.
+  Type '{ "Expected: any, Actual: number": never; }' has no call signatures.
 
 999   expectTypeOf(1).toBeAny()
                       ~~~~~~~
 test/usage.test.ts:999:999 - error TS2349: This expression is not callable.
-  Type 'ExpectNever<number>' has no call signatures.
+  Type '{ "Expected: never, Actual: number": never; }' has no call signatures.
 
 999   expectTypeOf(1).toBeNever()
                       ~~~~~~~~~
 test/usage.test.ts:999:999 - error TS2349: This expression is not callable.
-  Type 'ExpectNull<number>' has no call signatures.
+  Type '{ "Expected: null, Actual: number": never; }' has no call signatures.
 
 999   expectTypeOf(1).toBeNull()
                       ~~~~~~~~
 test/usage.test.ts:999:999 - error TS2349: This expression is not callable.
-  Type 'ExpectUndefined<number>' has no call signatures.
+  Type '{ "Expected: undefined, Actual: number": never; }' has no call signatures.
 
 999   expectTypeOf(1).toBeUndefined()
                       ~~~~~~~~~~~~~
 test/usage.test.ts:999:999 - error TS2349: This expression is not callable.
-  Type 'ExpectNullable<number>' has no call signatures.
+  Type '{ "Expected: nullable, Actual: number": never; }' has no call signatures.
 
 999   expectTypeOf(1).toBeNullable()
                       ~~~~~~~~~~~~
 test/usage.test.ts:999:999 - error TS2349: This expression is not callable.
-  Type 'ExpectBigInt<number>' has no call signatures.
+  Type '{ "Expected: bigint, Actual: number": never; }' has no call signatures.
 
 999   expectTypeOf(1).toBeBigInt()
                       ~~~~~~~~~~
@@ -140,7 +140,7 @@ test/usage.test.ts:999:999 - error TS2345: Argument of type '"c"' is not assigna
 999   expectTypeOf(obj).toHaveProperty('c')
                                        ~~~
 test/usage.test.ts:999:999 - error TS2349: This expression is not callable.
-  Type 'ExpectString<number>' has no call signatures.
+  Type '{ "Expected: string, Actual: number": never; }' has no call signatures.
 
 999   expectTypeOf(obj).toHaveProperty('a').toBeString()
                                             ~~~~~~~~~~
@@ -155,12 +155,12 @@ test/usage.test.ts:999:999 - error TS2344: Type '[number]' does not satisfy the 
 999   expectTypeOf<Factorize>().parameters.toEqualTypeOf<[number]>()
                                                          ~~~~~~~~
 test/usage.test.ts:999:999 - error TS2349: This expression is not callable.
-  Type 'ExpectAny<(a: number) => number[]>' has no call signatures.
+  Type '{ "Expected: any, Actual: function": never; }' has no call signatures.
 
 999   expectTypeOf(f).toBeAny()
                       ~~~~~~~
 test/usage.test.ts:999:999 - error TS2349: This expression is not callable.
-  Type 'ExpectAny<number[]>' has no call signatures.
+  Type '{ "Expected: any, Actual: ...": never; }' has no call signatures.
 
 999   expectTypeOf(f).returns.toBeAny()
                               ~~~~~~~
@@ -183,7 +183,7 @@ test/usage.test.ts:999:999 - error TS2345: Argument of type '(this: { name: stri
 999   expectTypeOf(greetFormal).toEqualTypeOf(greetCasual)
                                               ~~~~~~~~~~~
 test/usage.test.ts:999:999 - error TS2349: This expression is not callable.
-  Type 'ExpectString<number>' has no call signatures.
+  Type '{ "Expected: string, Actual: number": never; }' has no call signatures.
 
 999   expectTypeOf([1, 2, 3]).items.toBeString()
                                     ~~~~~~~~~~
@@ -218,10 +218,10 @@ test/usage.test.ts:999:999 - error TS2554: Expected 1 arguments, but got 0.
     999       ...MISMATCH: MismatchArgs<StrictEqualUsingTSInternalIdenticalToOperator<Actual, Expected>, true>
               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     Arguments for the rest parameter 'MISMATCH' were not provided.
-test/usage.test.ts:999:999 - error TS2344: Type '{ a: number | null; }' does not satisfy the constraint '{ a: "Expected: number, Actual: undefined" | "Expected: null, Actual: undefined"; }'.
+test/usage.test.ts:999:999 - error TS2344: Type '{ a: number | null; }' does not satisfy the constraint '{ a: "Expected: null, Actual: undefined" | "Expected: number, Actual: undefined"; }'.
   Types of property 'a' are incompatible.
-    Type 'number | null' is not assignable to type '"Expected: number, Actual: undefined" | "Expected: null, Actual: undefined"'.
-      Type 'null' is not assignable to type '"Expected: number, Actual: undefined" | "Expected: null, Actual: undefined"'.
+    Type 'number | null' is not assignable to type '"Expected: null, Actual: undefined" | "Expected: number, Actual: undefined"'.
+      Type 'null' is not assignable to type '"Expected: null, Actual: undefined" | "Expected: number, Actual: undefined"'.
 
 999   expectTypeOf<{a?: number | null}>().toEqualTypeOf<{a: number | null}>()
                                                         ~~~~~~~~~~~~~~~~~~

--- a/test/errors.test.ts
+++ b/test/errors.test.ts
@@ -194,7 +194,7 @@ test('toBeString', async () => {
   const badString = `expectTypeOf(1).toBeString()`
   expect(tsErrors(badString)).toMatchInlineSnapshot(`
     "test/test.ts:999:999 - error TS2349: This expression is not callable.
-      Type 'ExpectString<number>' has no call signatures.
+      Type '{ "Expected: string, Actual: number": never; }' has no call signatures.
 
     999 expectTypeOf(1).toBeString()
                         ~~~~~~~~~~"
@@ -205,7 +205,7 @@ test('toBeNullable', async () => {
   const okAssertion = `expectTypeOf<1 | undefined>().toBeNullable()`
   expect(tsErrors(okAssertion + '\n' + okAssertion.replace('.toBe', '.not.toBe'))).toMatchInlineSnapshot(`
     "test/test.ts:999:999 - error TS2349: This expression is not callable.
-      Type 'Inverted<ExpectNullable<1 | undefined>>' has no call signatures.
+      Type '{ "\`.not.toBeNullable()\` failed; Actual: undefined": never; "\`.not.toBeNullable()\` failed; Actual: literal number: 1": never; }' has no call signatures.
 
     999 expectTypeOf<1 | undefined>().not.toBeNullable()
                                           ~~~~~~~~~~~~"


### PR DESCRIPTION
## Summary

Improve error messages for `toBeAny()`, `toBeString()`, `toBeNumber()`, and other type assertion methods to clearly show expected vs actual types

Fixes #179

### Before

```
error TS2349: This expression is not callable.
  Type 'ExpectAny<2>' has no call signatures.
```

### After

```
error TS2349: This expression is not callable.
  Type '{ "Expected: any, Actual: literal number: 2": never; }' has no call signatures.
```

For negated assertions:

```
error TS2349: This expression is not callable.
  Type '{ ".not.toBeAny() failed; Actual: any": never; }' has no call signatures.
```