### PR TITLE
refactor!: rename `_ExpectTypeOf` exported type

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+onlyBuiltDependencies:
+  - esbuild

--- a/src/index.ts
+++ b/src/index.ts
@@ -993,7 +993,7 @@ const fn: any = () => true
 /**
  * Represents a function that allows asserting the expected type of a value.
  */
-export type _ExpectTypeOf = {
+export type ExpectTypeOfFunction = {
   /**
    * Asserts the expected type of a value.
    *
@@ -1034,7 +1034,7 @@ export type _ExpectTypeOf = {
  * @description
  * See the [full docs](https://npmjs.com/package/expect-type#documentation) for lots more examples.
  */
-export const expectTypeOf: _ExpectTypeOf = <Actual>(
+export const expectTypeOf: ExpectTypeOfFunction = <Actual>(
   _actual?: Actual,
 ): ExpectTypeOf<Actual, {positive: true; branded: false}> => {
   const nonFunctionProperties = [


### PR DESCRIPTION
# Summary

- Renames the exported type **`_ExpectTypeOf`** to **`ExpectTypeOfFunction`** to avoid confusion with **`ExpectTypeOf`** and follow conventional public API naming (no leading underscore).
- Resolves #106.

> [!CAUTION]
> Any consumers importing **`_ExpectTypeOf`** directly will need to update to the new name.