### PR TITLE
feat: support overloads in `thisParameter`

### DIFF
--- a/README.md
+++ b/README.md
@@ -551,6 +551,17 @@ function greet(this: {name: string}, message: string) {
 expectTypeOf(greet).thisParameter.toEqualTypeOf<{name: string}>()
 ```
 
+`thisParameter` supports overloads:
+
+```typescript
+type GreetOverloaded = {
+  (this: {name: string}, message: string): string
+  (this: {id: number}, message: string): string
+}
+
+expectTypeOf<GreetOverloaded>().thisParameter.toEqualTypeOf<{name: string} | {id: number}>()
+```
+
 Distinguish between functions with different `this` parameters:
 
 ```typescript

--- a/README.md
+++ b/README.md
@@ -562,6 +562,19 @@ type GreetOverloaded = {
 expectTypeOf<GreetOverloaded>().thisParameter.toEqualTypeOf<{name: string} | {id: number}>()
 ```
 
+`thisParameter` supports overloads where some overloads lack `this`:
+
+```typescript
+type GreetOverloaded = {
+  (this: {name: string}, message: string): string
+  (message: string): string
+}
+
+// When an overload lacks an explicit `this`, TypeScript infers `unknown` for it,
+// so the union `{name: string} | unknown` collapses to `unknown`.
+expectTypeOf<GreetOverloaded>().thisParameter.toBeUnknown()
+```
+
 Distinguish between functions with different `this` parameters:
 
 ```typescript

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+onlyBuiltDependencies:
+  - esbuild

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,6 +22,7 @@ import type {
   ConstructorOverloadParameters,
   OverloadParameters,
   OverloadReturnTypes,
+  OverloadThisParameterTypes,
   OverloadsNarrowedByParameters,
 } from './overloads'
 import type {
@@ -883,7 +884,7 @@ export interface BaseExpectTypeOf<Actual, Options extends {positive: boolean}> {
    * expectTypeOf(greet).thisParameter.toEqualTypeOf<{ name: string }>()
    * ```
    */
-  thisParameter: ExpectTypeOf<ThisParameterType<Actual>, Options>
+  thisParameter: ExpectTypeOf<OverloadThisParameterTypes<Actual>, Options>
 
   /**
    * Equivalent to the {@linkcode InstanceType} utility type.

--- a/src/overloads.ts
+++ b/src/overloads.ts
@@ -126,6 +126,199 @@ export type OverloadReturnTypes<FunctionType> =
   OverloadsInfoUnion<FunctionType> extends InferFunctionType<infer Fn> ? ReturnType<Fn> : never
 
 /**
+ * Like {@linkcode TSPost53OverloadsInfoUnion} but extracts only the
+ * `this` parameter types, using `(this: infer T, ...)` to preserve `this`
+ * before it gets stripped.
+ *
+ * @template FunctionType - the function type to extract `this` parameter types from.
+ */
+export type TSPost53OverloadThisParameterTypes<FunctionType> = FunctionType extends {
+  (this: infer T1, ...args: any[]): any
+  (this: infer T2, ...args: any[]): any
+  (this: infer T3, ...args: any[]): any
+  (this: infer T4, ...args: any[]): any
+  (this: infer T5, ...args: any[]): any
+  (this: infer T6, ...args: any[]): any
+  (this: infer T7, ...args: any[]): any
+  (this: infer T8, ...args: any[]): any
+  (this: infer T9, ...args: any[]): any
+  (this: infer T10, ...args: any[]): any
+}
+  ? T1 | T2 | T3 | T4 | T5 | T6 | T7 | T8 | T9 | T10
+  : never
+
+/**
+ * Like {@linkcode DecreasingOverloadsInfoUnion} but preserves the
+ * `this` parameter in each extracted function variant so that it can be
+ * used for filtering and `this` type extraction.
+ *
+ * @template FunctionType - the function type to extract overload info from.
+ */
+export type DecreasingOverloadsInfoUnionWithThis<FunctionType> = FunctionType extends {
+  (this: infer T1, ...args: infer A1): infer R1
+  (this: infer T2, ...args: infer A2): infer R2
+  (this: infer T3, ...args: infer A3): infer R3
+  (this: infer T4, ...args: infer A4): infer R4
+  (this: infer T5, ...args: infer A5): infer R5
+  (this: infer T6, ...args: infer A6): infer R6
+  (this: infer T7, ...args: infer A7): infer R7
+  (this: infer T8, ...args: infer A8): infer R8
+  (this: infer T9, ...args: infer A9): infer R9
+  (this: infer T10, ...args: infer A10): infer R10
+}
+  ?
+      | ((this: T1, ...args: A1) => R1)
+      | ((this: T2, ...args: A2) => R2)
+      | ((this: T3, ...args: A3) => R3)
+      | ((this: T4, ...args: A4) => R4)
+      | ((this: T5, ...args: A5) => R5)
+      | ((this: T6, ...args: A6) => R6)
+      | ((this: T7, ...args: A7) => R7)
+      | ((this: T8, ...args: A8) => R8)
+      | ((this: T9, ...args: A9) => R9)
+      | ((this: T10, ...args: A10) => R10)
+  : FunctionType extends {
+        (this: infer T1, ...args: infer A1): infer R1
+        (this: infer T2, ...args: infer A2): infer R2
+        (this: infer T3, ...args: infer A3): infer R3
+        (this: infer T4, ...args: infer A4): infer R4
+        (this: infer T5, ...args: infer A5): infer R5
+        (this: infer T6, ...args: infer A6): infer R6
+        (this: infer T7, ...args: infer A7): infer R7
+        (this: infer T8, ...args: infer A8): infer R8
+        (this: infer T9, ...args: infer A9): infer R9
+      }
+    ?
+        | ((this: T1, ...args: A1) => R1)
+        | ((this: T2, ...args: A2) => R2)
+        | ((this: T3, ...args: A3) => R3)
+        | ((this: T4, ...args: A4) => R4)
+        | ((this: T5, ...args: A5) => R5)
+        | ((this: T6, ...args: A6) => R6)
+        | ((this: T7, ...args: A7) => R7)
+        | ((this: T8, ...args: A8) => R8)
+        | ((this: T9, ...args: A9) => R9)
+    : FunctionType extends {
+          (this: infer T1, ...args: infer A1): infer R1
+          (this: infer T2, ...args: infer A2): infer R2
+          (this: infer T3, ...args: infer A3): infer R3
+          (this: infer T4, ...args: infer A4): infer R4
+          (this: infer T5, ...args: infer A5): infer R5
+          (this: infer T6, ...args: infer A6): infer R6
+          (this: infer T7, ...args: infer A7): infer R7
+          (this: infer T8, ...args: infer A8): infer R8
+        }
+      ?
+          | ((this: T1, ...args: A1) => R1)
+          | ((this: T2, ...args: A2) => R2)
+          | ((this: T3, ...args: A3) => R3)
+          | ((this: T4, ...args: A4) => R4)
+          | ((this: T5, ...args: A5) => R5)
+          | ((this: T6, ...args: A6) => R6)
+          | ((this: T7, ...args: A7) => R7)
+          | ((this: T8, ...args: A8) => R8)
+      : FunctionType extends {
+            (this: infer T1, ...args: infer A1): infer R1
+            (this: infer T2, ...args: infer A2): infer R2
+            (this: infer T3, ...args: infer A3): infer R3
+            (this: infer T4, ...args: infer A4): infer R4
+            (this: infer T5, ...args: infer A5): infer R5
+            (this: infer T6, ...args: infer A6): infer R6
+            (this: infer T7, ...args: infer A7): infer R7
+          }
+        ?
+            | ((this: T1, ...args: A1) => R1)
+            | ((this: T2, ...args: A2) => R2)
+            | ((this: T3, ...args: A3) => R3)
+            | ((this: T4, ...args: A4) => R4)
+            | ((this: T5, ...args: A5) => R5)
+            | ((this: T6, ...args: A6) => R6)
+            | ((this: T7, ...args: A7) => R7)
+        : FunctionType extends {
+              (this: infer T1, ...args: infer A1): infer R1
+              (this: infer T2, ...args: infer A2): infer R2
+              (this: infer T3, ...args: infer A3): infer R3
+              (this: infer T4, ...args: infer A4): infer R4
+              (this: infer T5, ...args: infer A5): infer R5
+              (this: infer T6, ...args: infer A6): infer R6
+            }
+          ?
+              | ((this: T1, ...args: A1) => R1)
+              | ((this: T2, ...args: A2) => R2)
+              | ((this: T3, ...args: A3) => R3)
+              | ((this: T4, ...args: A4) => R4)
+              | ((this: T5, ...args: A5) => R5)
+              | ((this: T6, ...args: A6) => R6)
+          : FunctionType extends {
+                (this: infer T1, ...args: infer A1): infer R1
+                (this: infer T2, ...args: infer A2): infer R2
+                (this: infer T3, ...args: infer A3): infer R3
+                (this: infer T4, ...args: infer A4): infer R4
+                (this: infer T5, ...args: infer A5): infer R5
+              }
+            ?
+                | ((this: T1, ...args: A1) => R1)
+                | ((this: T2, ...args: A2) => R2)
+                | ((this: T3, ...args: A3) => R3)
+                | ((this: T4, ...args: A4) => R4)
+                | ((this: T5, ...args: A5) => R5)
+            : FunctionType extends {
+                  (this: infer T1, ...args: infer A1): infer R1
+                  (this: infer T2, ...args: infer A2): infer R2
+                  (this: infer T3, ...args: infer A3): infer R3
+                  (this: infer T4, ...args: infer A4): infer R4
+                }
+              ?
+                  | ((this: T1, ...args: A1) => R1)
+                  | ((this: T2, ...args: A2) => R2)
+                  | ((this: T3, ...args: A3) => R3)
+                  | ((this: T4, ...args: A4) => R4)
+              : FunctionType extends {
+                    (this: infer T1, ...args: infer A1): infer R1
+                    (this: infer T2, ...args: infer A2): infer R2
+                    (this: infer T3, ...args: infer A3): infer R3
+                  }
+                ? ((this: T1, ...args: A1) => R1) | ((this: T2, ...args: A2) => R2) | ((this: T3, ...args: A3) => R3)
+                : FunctionType extends {
+                      (this: infer T1, ...args: infer A1): infer R1
+                      (this: infer T2, ...args: infer A2): infer R2
+                    }
+                  ? ((this: T1, ...args: A1) => R1) | ((this: T2, ...args: A2) => R2)
+                  : FunctionType extends (this: infer T1, ...args: infer A1) => infer R1
+                    ? (this: T1, ...args: A1) => R1
+                    : never
+
+/**
+ * Like {@linkcode TSPre53OverloadsInfoUnion} but extracts the
+ * `this` parameter types, using
+ * {@linkcode DecreasingOverloadsInfoUnionWithThis} to preserve `this`
+ * through the filtering step.
+ *
+ * @template FunctionType - the function type to extract `this` parameter types from.
+ */
+export type TSPre53OverloadThisParameterTypes<FunctionType> =
+  Tuplify<DecreasingOverloadsInfoUnionWithThis<FunctionType>> extends infer TupleType
+    ? TupleType extends [infer OverloadedFunctionType]
+      ? IsUselessOverloadInfo<OverloadedFunctionType> extends true
+        ? never
+        : OverloadedFunctionType extends (this: infer InferredThisType, ...args: any[]) => any
+          ? InferredThisType
+          : never
+      : never
+    : never
+
+/**
+ * A union type of the `this` parameter types for any overload of
+ * function {@linkcode FunctionType}.
+ *
+ * @template FunctionType - the function type to extract `this` parameter types from.
+ */
+export type OverloadThisParameterTypes<FunctionType> =
+  IsNever<TSPost53OverloadsInfoUnion<(a: 1) => 2>> extends true
+    ? TSPre53OverloadThisParameterTypes<FunctionType>
+    : TSPost53OverloadThisParameterTypes<FunctionType>
+
+/**
  * Takes an overload variants {@linkcode Union},
  * produced from {@linkcode OverloadsInfoUnion} and rejects
  * the ones incompatible with parameters {@linkcode Args}.

--- a/src/overloads.ts
+++ b/src/overloads.ts
@@ -313,10 +313,11 @@ export type TSPre53OverloadThisParameterTypes<FunctionType> =
  *
  * @template FunctionType - the function type to extract `this` parameter types from.
  */
-export type OverloadThisParameterTypes<FunctionType> =
-  IsNever<TSPost53OverloadsInfoUnion<(a: 1) => 2>> extends true
+export type OverloadThisParameterTypes<FunctionType> = FunctionType extends (...args: any[]) => any
+  ? IsNever<TSPost53OverloadsInfoUnion<(a: 1) => 2>> extends true
     ? TSPre53OverloadThisParameterTypes<FunctionType>
     : TSPost53OverloadThisParameterTypes<FunctionType>
+  : ThisParameterType<FunctionType>
 
 /**
  * Takes an overload variants {@linkcode Union},

--- a/test/usage.test.ts
+++ b/test/usage.test.ts
@@ -414,6 +414,15 @@ test('Check function `this` parameters', () => {
   expectTypeOf(greet).thisParameter.toEqualTypeOf<{name: string}>()
 })
 
+test('`thisParameter` supports overloads', () => {
+  type GreetOverloaded = {
+    (this: {name: string}, message: string): string
+    (this: {id: number}, message: string): string
+  }
+
+  expectTypeOf<GreetOverloaded>().thisParameter.toEqualTypeOf<{name: string} | {id: number}>()
+})
+
 test('Distinguish between functions with different `this` parameters', () => {
   function greetFormal(this: {title: string; name: string}, message: string) {
     return `Dear ${this.title} ${this.name}, here's your message: ${message}`

--- a/test/usage.test.ts
+++ b/test/usage.test.ts
@@ -423,6 +423,17 @@ test('`thisParameter` supports overloads', () => {
   expectTypeOf<GreetOverloaded>().thisParameter.toEqualTypeOf<{name: string} | {id: number}>()
 })
 
+test('`thisParameter` supports overloads where some overloads lack `this`', () => {
+  type GreetOverloaded = {
+    (this: {name: string}, message: string): string
+    (message: string): string
+  }
+
+  // When an overload lacks an explicit `this`, TypeScript infers `unknown` for it,
+  // so the union `{name: string} | unknown` collapses to `unknown`.
+  expectTypeOf<GreetOverloaded>().thisParameter.toBeUnknown()
+})
+
 test('Distinguish between functions with different `this` parameters', () => {
   function greetFormal(this: {title: string; name: string}, message: string) {
     return `Dear ${this.title} ${this.name}, here's your message: ${message}`


### PR DESCRIPTION
## Summary

`thisParameter` now treats overloaded call signatures like the existing `parameters` and `returns` helpers: it considers the whole overload set instead of delegating directly to TypeScript's `ThisParameterType`, which only reflects one signature from an overloaded type.

For users, this means `thisParameter` can now describe every explicit receiver type:

```ts
type Greet = {
  (this: {name: string}, message: string): string
  (this: {id: number}, message: string): string
}

// Before this PR: only one overload's receiver was visible.
expectTypeOf<Greet>().thisParameter.toEqualTypeOf<{name: string} | {id: number}>()
```

It also handles overload sets where any signature lacks an explicit `this`. TypeScript treats that receiver as `unknown`, so the final receiver type is `unknown` instead of whichever explicit receiver happened to be visible from the old single-signature extraction:

```ts
type MaybeBoundGreet = {
  (message: string): string
  (this: {name: string}, message: string): string
}

expectTypeOf<MaybeBoundGreet>().thisParameter.toBeUnknown()
```

## Implementation

- Adds `OverloadThisParameterTypes`, with the same TypeScript-version split used by the existing overload helpers.
- Preserves `this` while decomposing overloads, then unions the extracted receiver types.
- Updates `thisParameter` to use the overload-aware extractor.
- Documents the overload behavior and adds regression coverage for explicit receiver overloads and the missing-`this` case.
- Adds pnpm workspace config to approve `esbuild`'s install script under pnpm 10.

## Validation

- Confirmed against `origin/main` that the old implementation observes a single overload signature: reversing overload order changes the inferred `this` type, and a no-`this` overload can be missed if it is not the visible signature.
- Confirmed on this branch that explicit receiver overloads produce a receiver union, and overload sets with a no-`this` signature produce `unknown` regardless of order.
- `pnpm type-check`
- `pnpm test`

Resolves #168.
