### PR TITLE
chore: gate Renovate dependency PRs

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -8,5 +8,7 @@
   ],
   "automerge": true,
   "automergeType": "branch",
+  "prCreation": "approval",
+  "dependencyDashboard": true,
   "fetchChangeLogs": "branch"
 }


### PR DESCRIPTION
## Summary

Renovate now creates update branches without automatically opening per-dependency PRs. Per-dependency PRs are gated behind Dependency Dashboard approval instead, while `mmkal/runovate` remains responsible for the aggregate `deps -> main` pull request.

This should reduce failed-update PR spam while still keeping blocked dependency updates visible in the Dependency Dashboard.

## Behavior

- Successful Renovate branches can still automerge into `deps` via `automergeType: "branch"`.
- `runovate` still creates or updates the roll-up dependency PR from `deps` into `main`.
- Failed or otherwise blocked Renovate branches stay visible in the Dependency Dashboard instead of becoming automatic PRs.
- A per-dependency PR can still be requested manually from the dashboard when that is useful.

## Validation

- `node -e "JSON.parse(require('fs').readFileSync('renovate.json','utf8')); console.log('renovate.json is valid JSON')"`
- `pnpm dlx --package=renovate renovate-config-validator`

The Renovate validator still reports the existing `baseBranches` -> `baseBranchPatterns` migration warning. This PR leaves that alone because `mmkal/runovate` currently writes `baseBranches` as part of its required config.
