### PR TITLE
test: lock non-callable thisParameter fallback

### DIFF
--- a/test/types.test.ts
+++ b/test/types.test.ts
@@ -80,6 +80,13 @@ test(`never types don't sneak by`, () => {
   expectTypeOf<never>().toMatchTypeOf<{foo: string}>()
 })
 
+test('thisParameter returns unknown for non-callable types', () => {
+  expectTypeOf<ThisParameterType<number>>().toBeUnknown()
+  expectTypeOf<number>().thisParameter.toBeUnknown()
+  // @ts-expect-error
+  expectTypeOf<number>().thisParameter.toBeNever()
+})
+
 test("any/never types don't break toEqualTypeOf or toMatchTypeOf", () => {
   // @ts-expect-error
   expectTypeOf<never>().toEqualTypeOf<any>()

--- a/test/types.test.ts
+++ b/test/types.test.ts
@@ -83,8 +83,6 @@ test(`never types don't sneak by`, () => {
 test('thisParameter returns unknown for non-callable types', () => {
   expectTypeOf<ThisParameterType<number>>().toBeUnknown()
   expectTypeOf<number>().thisParameter.toBeUnknown()
-  // @ts-expect-error
-  expectTypeOf<number>().thisParameter.toBeNever()
 })
 
 test("any/never types don't break toEqualTypeOf or toMatchTypeOf", () => {


### PR DESCRIPTION
## Summary

Adds regression coverage for `.thisParameter` on non-callable types. The helper is documented as equivalent to `ThisParameterType`, and TypeScript returns `unknown` when the input is not callable:

```ts
expectTypeOf<ThisParameterType<number>>().toBeUnknown()
expectTypeOf<number>().thisParameter.toBeUnknown()
```

This locks in that `.thisParameter` should preserve the `ThisParameterType` fallback for non-callable inputs.

## Validation

- `pnpm type-check`
